### PR TITLE
Update System Module for CMake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+build
 hclib-install
 compileTree
 config

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,10 +20,37 @@ set (HCLIB_VERSION_MINOR 1)
 
 enable_testing()
 
+
 option(HCLIB_ENABLE_VERBOSE     "whether verbose HC runtime"          OFF)
 option(HCLIB_ENABLE_STATS       "whether to turn on HC runtime stats" OFF)
 option(HCLIB_ENABLE_HWLOC       "whether to enable HWLoc"             OFF)
 option(HCLIB_ENABLE_PRODUCTION  "disable assertions and stats"        OFF)
+
+set(COMPILE_DEFINITIONS "")
+
+if (HCLIB_ENABLE_HWLOC)
+    list(APPEND COMPILE_DEFINITIONS USE_HWLOC)
+endif(HCLIB_ENABLE_HWLOC)
+
+if (HCLIB_ENABLE_STATS)
+    list(APPEND COMPILE_DEFINITIONS HCLIB_STATS)
+endif(HCLIB_ENABLE_STATS)
+
+if (HCLIB_ENABLE_VERBOSE)
+    list(APPEND COMPILE_DEFINITIONS VERBOSE)
+endif(HCLIB_ENABLE_VERBOSE)
+
+if (HCLIB_ENABLE_PRODUCTION)
+    list(APPEND COMPILE_DEFINITIONS HC_ASSERTION_CHECK)
+endif()
+
+
+
+set(HCLIB_MODULES "system" CACHE STRING "A semicolon separated list of modules to compile")
+
+if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+    set (CMAKE_INSTALL_PREFIX "${CMAKE_CURRENT_SOURCE_DIR}/hclib-install" CACHE PATH "default install path" FORCE )
+endif()
 
 configure_file(
  ${CMAKE_CURRENT_SOURCE_DIR}/inc/hclib_config.h.in
@@ -31,6 +58,10 @@ configure_file(
 )
 
 add_subdirectory(src)
+
+foreach(_mod ${HCLIB_MODULES})
+    add_subdirectory("modules/${_mod}")
+endforeach()
 
 include(CMakePackageConfigHelpers)
 configure_package_config_file(cmake/hclibConfig.cmake.in

--- a/cmake/hclibConfig.cmake.in
+++ b/cmake/hclibConfig.cmake.in
@@ -5,6 +5,9 @@ include(CMakeFindDependencyMacro)
 # Any frontend dependencies
 include("${CMAKE_CURRENT_LIST_DIR}/hclibTargets.cmake")
 
-
+#Check for the module dependencies.
+foreach(_mod ${hclib_FIND_COMPONENTS})
+    include("${CMAKE_CURRENT_LIST_DIR}/hclib_${_mod}Targets.cmake")
+endforeach()
 
 

--- a/modules/system/CMakeLists.txt
+++ b/modules/system/CMakeLists.txt
@@ -1,0 +1,30 @@
+SET(MODULE_NAME "system")
+
+FILE(GLOB SOURCES "${CMAKE_CURRENT_LIST_DIR}/src/*.cpp" "${CMAKE_CURRENT_LIST_DIR}/src/*.c")
+FILE(GLOB HEADERS "${CMAKE_CURRENT_LIST_DIR}/inc/*.h")
+
+ADD_LIBRARY("hclib_${MODULE_NAME}" MODULE "${SOURCES}")
+
+target_link_libraries("hclib_${MODULE_NAME}" PRIVATE hclib)
+
+target_compile_features("hclib_${MODULE_NAME}" PUBLIC c_std_11)
+target_compile_features("hclib_${MODULE_NAME}" PUBLIC cxx_std_11)
+
+target_include_directories("hclib_${MODULE_NAME}"
+    PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/inc>
+    $<INSTALL_INTERFACE:include>)
+
+target_compile_definitions(hclib PRIVATE COMPILE_DEFINITIONS)
+
+install(TARGETS "hclib_${MODULE_NAME}" EXPORT "hclib_${MODULE_NAME}-targets"
+        INCLUDES DESTINATION include
+        ARCHIVE DESTINATION lib
+        LIBRARY DESTINATION lib)
+
+install(EXPORT "hclib_${MODULE_NAME}-targets"
+    FILE "hclib_${MODULE_NAME}Targets.cmake"
+    NAMESPACE hclib::
+    DESTINATION cmake)
+
+install(FILES ${HEADERS} DESTINATION include)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -37,7 +37,7 @@ elseif (CMAKE_SYSTEM_NAME STREQUAL "Linux")
     fcontext/make_x86_64_sysv_elf_gas.S)
 endif()
 
-add_library(hclib ${SOURCES})
+add_library(hclib SHARED ${SOURCES})
 
 target_compile_features(hclib PUBLIC c_std_11)
 target_compile_features(hclib PUBLIC cxx_std_11)
@@ -73,24 +73,13 @@ install(EXPORT hclib
         DESTINATION cmake)
 
 
+target_compile_definitions(hclib PRIVATE COMPILE_DEFINITIONS)
+
 if (HCLIB_ENABLE_HWLOC)
-target_compile_definitions(hclib USE_HWLOC)
 target_include_directories(hclib ${HWLOC_HOME}/include)
 target_link_directories(hclib PUBLIC ${HWLOC_HOME}/lib)
 target_link_libraries(hclib PUBLIC hwloc)
 endif(HCLIB_ENABLE_HWLOC)
-
-if (HCLIB_ENABLE_STATS)
-target_compile_definitions(hclib HCLIB_STATS)
-endif(HCLIB_ENABLE_STATS)
-
-if (HCLIB_ENABLE_VERBOSE)
-target_compile_definitions(hclib VERBOSE)
-endif(HCLIB_ENABLE_VERBOSE)
-
-if (HCLIB_ENABLE_PRODUCTION)
-target_compile_definitions(hclib HC_ASSERTION_CHECK)
-endif()
 
 if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
   target_link_libraries(hclib PUBLIC pthread)

--- a/test/cpp/CMakeLists.txt
+++ b/test/cpp/CMakeLists.txt
@@ -4,15 +4,9 @@ project (HCLIB_async0)
 
 add_executable(async0
   async0.cpp
-  $ENV{HCLIB_ROOT}/../modules/system/src/hclib_system.cpp
 )
 
-find_package(hclib REQUIRED)
+find_package(hclib REQUIRED system)
 
-target_link_libraries(async0 hclib::hclib)
-
-set(HCLIB_MOD_SYS_INC
-    $ENV{HCLIB_ROOT}/../modules/system/inc
-)
-target_include_directories(async0 PUBLIC ${HCLIB_MOD_SYS_INC})
+target_link_libraries(async0 hclib::hclib hclib::hclib_system)
 


### PR DESCRIPTION
Setup a system for users to compile/link-to modules using CMake's components feature. Specify which modules to compile with -DHCLIB_MODULES="system;ref-counting;etc". See CMakeLists.txt for in test/cpp for example compiling usage.

Also updated to set $CMAKE_CURRENT_SOURCE_DIR/hclib-install as default install dir if user doesn't specify.