### PR TITLE
Add HClib library function to create a new file for trace output

### DIFF
--- a/modules/bale_actor/inc/selector.h
+++ b/modules/bale_actor/inc/selector.h
@@ -44,7 +44,7 @@ FILE *get_trace_fptr(bool is_new, const char name[] = "") {
 /*
   Library function to create a new file for trace output, e.g.:
     char name[32];
-    sprintf(name, "phase_%d", 3);
+    sprintf(name, "phase%d", 3);
     hclib::new_file_for_selector_trace(name);
     // Trace output is written to the file named "PE*_phase3_send.csv".
  */


### PR DESCRIPTION
This is an extension to the "selector trace" functionality.

A new function `hclib::new_file_for_selector_trace(char name[])` is added, which allows users to specify separate trace output files for different execution phases (e.g., different finish regions), for instance:
```
  for (i = 0; i < total_phases; i++) {
    char name[32];
    sprintf(name, "phase%d", i);
    hclib::new_file_for_selector_trace(name);
    MySelector *ptr = new MySelector(...);
    hclib::finish([=]() {
      ...
    });
  }
```
When `i = 3`, the trace output for `PE = 42` is written to the file named `PE42_phase3_send.csv`.