### PR TITLE
Adding support for global mailbox termination (done) across all PEs

### DIFF
--- a/modules/bale_actor/inc/selector.h
+++ b/modules/bale_actor/inc/selector.h
@@ -672,14 +672,14 @@ class Selector {
 
         shmem_barrier_all();
 
-        if(shmem_my_pe()==0){
-            printf("Global Done initialized\n");
-            for (int i = 0; i < shmem_n_pes(); i++) {
-                int value_global_done = shmem_int_g(GLOBAL_DONE, i);
-                int value_local_done = shmem_int_g(LOCAL_DONE, i);
-                printf("PE: %d, GLOBAL_DONE: %d, LOCAL_DONE: %d\n", i, value_global_done, value_local_done);
-            }
-        }
+        // if(shmem_my_pe()==0){
+        //     for (int i = 0; i < shmem_n_pes(); i++) {
+        //         int value_global_done = shmem_int_g(GLOBAL_DONE, i);
+        //         int value_local_done = shmem_int_g(LOCAL_DONE, i);
+        //         printf("PE: %d, GLOBAL_DONE: %d, LOCAL_DONE: %d\n", i, value_global_done, value_local_done);
+        //     }
+        //     printf("Global Done initialized\n");
+        // }
     }
 
 #ifdef ENABLE_TRACE
@@ -880,10 +880,10 @@ class Selector {
 #endif // USE_LAMBDA
 
     void initiate_global_done() { // signals current PE termination
-        // need extra layer with LOCAL_DONE because some apps require mailboxes to send messages
-        //  within the "request" that they are serving, so this keeps the mailbox active to do that
+        // need extra layer with LOCAL_DONE because some apps require mbs to send messages
+        //  within the "request" that they are serving, so this keeps the mb active to do that
 
-        shmem_int_p(LOCAL_DONE, 1, shmem_my_pe()); 
+        *LOCAL_DONE = 1; 
 
         int global_done_flag = 0;
         int local_done_value;
@@ -891,6 +891,7 @@ class Selector {
         // fetch LOCAL_DONE on all PEs
         for (int pe_id = 0; pe_id < shmem_n_pes(); pe_id++) {
             local_done_value = shmem_int_g(LOCAL_DONE, pe_id);
+            if ( !local_done_value ) { break; }
             global_done_flag += local_done_value;
         }
 

--- a/modules/bale_actor/test/Makefile
+++ b/modules/bale_actor/test/Makefile
@@ -4,7 +4,7 @@ include $(HCLIB_ROOT)/../modules/bale_actor/inc/hclib_bale_actor.post.mak
 
 SRUN ?= oshrun
 
-TARGETS=microtest_selector dependency_cyclic_selector dependency_selector factorial_selector \
+TARGETS=microtest_global_done_selector microtest_initiate_local_done_selector dependency_cyclic_selector dependency_selector factorial_selector \
 	test_conveyor test_selector test_selector3 \
         histo_agi histo_conveyor histo_selector histo_selector_lambda histo_selector_lambda2  histo_agi_selector\
         ig_agi ig_conveyor ig_selector ig_selector_lambda ig_selector_lambda2 ig_agi_selector\

--- a/modules/bale_actor/test/Makefile
+++ b/modules/bale_actor/test/Makefile
@@ -4,7 +4,7 @@ include $(HCLIB_ROOT)/../modules/bale_actor/inc/hclib_bale_actor.post.mak
 
 SRUN ?= oshrun
 
-TARGETS=dependency_cyclic_selector dependency_selector factorial_selector \
+TARGETS=microtest_selector dependency_cyclic_selector dependency_selector factorial_selector \
 	test_conveyor test_selector test_selector3 \
         histo_agi histo_conveyor histo_selector histo_selector_lambda histo_selector_lambda2  histo_agi_selector\
         ig_agi ig_conveyor ig_selector ig_selector_lambda ig_selector_lambda2 ig_agi_selector\

--- a/modules/bale_actor/test/microtest_global_done_selector.cpp
+++ b/modules/bale_actor/test/microtest_global_done_selector.cpp
@@ -67,7 +67,7 @@ class ClientActor: public hclib::Selector<2, packet> {
     void process_response(packet pkt, int sender_rank) {
         std::cout<<"Client recieved response from PE"<<sender_rank<<std::endl;
         std::cout<<"...should terminate here..."<<std::endl;
-        initiate_global_done();
+        global_done();
     }
     public:
     void start() {

--- a/modules/bale_actor/test/microtest_initiate_local_done_selector.cpp
+++ b/modules/bale_actor/test/microtest_initiate_local_done_selector.cpp
@@ -1,0 +1,147 @@
+#include <iostream>
+#include <shmem.h>
+#include "selector.h"
+#include <map>
+#include <string>
+
+// mock format for HTTP message 
+// struct MockHTTPMessage {
+    // std::string method;
+    // std::string path;
+    // std::string version;
+    // std::map<std::string, std::string> headers;
+    // std::string body;
+// };
+struct packet {
+    int64_t id;
+    int64_t dest;
+    int64_t src;
+};
+
+enum MailBoxType{REQUEST, REPLY};
+
+// Dual Mapping from PE role to PE number
+std::map<std::string, int> role_to_pe = {
+  {"client", 0},
+  {"gateway", 1},
+  {"service_A", 2},
+  {"service_B", 3}
+};
+
+class GatewayActor: public hclib::Selector<2, packet> {
+    //std::map<int64_t, packet> service_queue;
+
+    void process_request(packet pkt, int sender_rank) {
+        //
+        // forward to correct PE
+        std::cout<<"PE"<<shmem_my_pe()<<": Gateway received request from PE"<<sender_rank<<std::endl;
+        //service_queue[pkt.id] = pkt;
+        auto rank = role_to_pe["service_A"];
+        send(REQUEST, pkt, 2);
+        std::cout<<"PE"<<shmem_my_pe()<<": Gateway sent request to Service@PE"<<rank<<std::endl;
+    }
+    void process_response(packet pkt, int sender_rank) {
+        // send to client
+        std::cout<<"Gateway received response from PE"<<sender_rank<<std::endl;
+        // fetch request from queue
+        //service_queue.erase(pkt.id);
+        send(REPLY, pkt, role_to_pe["client"]);
+        initiate_global_done();
+    }
+    public:
+    void start() {
+        std::cout<<"Gateway started"<<std::endl;
+        hclib::Selector<2, packet>::start();
+    }
+    GatewayActor() {
+        std::cout<<"PE"<<shmem_my_pe()<<": GatewayActor initialized"<<std::endl;
+        mb[REQUEST].process = [this](packet pkt, int sender_rank) { this->process_request(pkt, sender_rank);};
+        mb[REPLY].process = [this](packet pkt, int sender_rank) { this->process_response(pkt, sender_rank);};
+    }
+};
+
+class ClientActor: public hclib::Selector<2, packet> {
+
+    void process_request(packet pkt, int sender_rank) {
+        send(REQUEST, pkt, role_to_pe["gateway"]);
+    }
+    void process_response(packet pkt, int sender_rank) {
+        std::cout<<"Client recieved response from PE"<<sender_rank<<std::endl;
+        std::cout<<"...should terminate here..."<<std::endl;
+        initiate_global_done();
+    }
+    public:
+    void start() {
+        std::cout<<"Client started"<<std::endl;
+        hclib::Selector<2, packet>::start();
+    }
+    ClientActor() {
+        std::cout<<"PE"<<shmem_my_pe()<<": ClientActor initialized"<<std::endl;
+        mb[REQUEST].process = [this](packet pkt, int sender_rank) { this->process_request(pkt, sender_rank);};
+        mb[REPLY].process = [this](packet pkt, int sender_rank) { this->process_response(pkt, sender_rank);};
+    }
+};
+
+class ServiceActor: public hclib::Selector<2, packet> {
+    void process_request(packet pkt, int sender_rank) {
+        std::cout<<"(request) Service received request from PE"<<sender_rank<<std::endl;
+        send(REPLY, pkt, shmem_my_pe());
+    }
+    void process_reply(packet pkt, int sender_rank) {
+        std::cout<<"(reply) Service received request from PE"<<role_to_pe["gateway"]<<std::endl;
+        send(REPLY, pkt, role_to_pe["gateway"]);
+        initiate_global_done();  
+    }
+    public:
+    void start() {
+        std::cout<<"Service started"<<std::endl;
+        hclib::Selector<2, packet>::start();
+    }
+    ServiceActor() {
+        std::cout<<"PE"<<shmem_my_pe()<<": ServiceActor initialized"<<std::endl;
+        mb[REQUEST].process = [this](packet pkt, int sender_rank) { this->process_request(pkt, sender_rank);};
+        mb[REPLY].process = [this](packet pkt, int sender_rank) { this->process_reply(pkt, sender_rank);};
+    }
+};
+
+// SPMD
+int main(int argc, char * argv[]) {
+  // Initialize SHMEM
+  // shmem_init();
+
+  const char *deps[] = { "system", "bale_actor" };
+  hclib::launch(deps, 2, [=] {
+    std::cout<<"Starting with "<<shmem_n_pes()<<" PEs"<<std::endl;
+    hclib::Selector<2, packet>* current_actor;
+    switch(shmem_my_pe()) {
+        case 0:
+            current_actor = new ClientActor();
+            break;
+        case 1:
+            current_actor = new GatewayActor();
+            break;
+        case 2:
+            current_actor = new ServiceActor();
+            break;
+    }
+    shmem_barrier_all();
+    hclib::finish([=]() {
+        
+        current_actor->start();
+        if (shmem_my_pe() == role_to_pe["client"]) {
+            packet pkt;
+            pkt.id = 1;
+            pkt.dest = role_to_pe["service_A"];
+            pkt.src = role_to_pe["client"];
+            current_actor->send(REQUEST, pkt, shmem_my_pe()); //dummy message so can have (outside) -> PE0 mb[REQUEST] 
+        }
+        //if (shmem_my_pe() == 0) {
+        //    current_actor->done(REQUEST);
+        //}
+    });
+    shmem_barrier_all();
+  });
+  // Finalize SHMEM
+  // shmem_finalize();
+  return 0;
+}

--- a/modules/bale_actor/test/microtest_selector.cpp
+++ b/modules/bale_actor/test/microtest_selector.cpp
@@ -1,0 +1,145 @@
+#include <iostream>
+#include <shmem.h>
+#include "selector.h"
+#include <map>
+#include <string>
+
+// mock format for HTTP message 
+// struct MockHTTPMessage {
+    // std::string method;
+    // std::string path;
+    // std::string version;
+    // std::map<std::string, std::string> headers;
+    // std::string body;
+// };
+struct packet {
+    int64_t id;
+    int64_t dest;
+    int64_t src;
+};
+
+enum MailBoxType{REQUEST, REPLY};
+
+// Dual Mapping from PE role to PE number
+std::map<std::string, int> role_to_pe = {
+  {"client", 0},
+  {"gateway", 1},
+  {"service_A", 2},
+  {"service_B", 3}
+};
+
+class GatewayActor: public hclib::Selector<2, packet> {
+    //std::map<int64_t, packet> service_queue;
+
+    void process_request(packet pkt, int sender_rank) {
+        //
+        // forward to correct PE
+        std::cout<<"PE"<<shmem_my_pe()<<": Gateway received request from PE"<<sender_rank<<std::endl;
+        //service_queue[pkt.id] = pkt;
+        auto rank = role_to_pe["service_A"];
+        send(REQUEST, pkt, 2);
+        std::cout<<"PE"<<shmem_my_pe()<<": Gateway sent request to Service@PE"<<rank<<std::endl;
+    }
+    void process_response(packet pkt, int sender_rank) {
+        // send to client
+        std::cout<<"Gateway received response from PE"<<sender_rank<<std::endl;
+        // fetch request from queue
+        //service_queue.erase(pkt.id);
+        send(REPLY, pkt, role_to_pe["client"]);
+    }
+    public:
+    void start() {
+        std::cout<<"Gateway started"<<std::endl;
+        hclib::Selector<2, packet>::start();
+    }
+    GatewayActor() {
+        std::cout<<"PE"<<shmem_my_pe()<<": GatewayActor initialized"<<std::endl;
+        mb[REQUEST].process = [this](packet pkt, int sender_rank) { this->process_request(pkt, sender_rank);};
+        mb[REPLY].process = [this](packet pkt, int sender_rank) { this->process_response(pkt, sender_rank);};
+    }
+};
+
+class ClientActor: public hclib::Selector<2, packet> {
+
+    void process_request(packet pkt, int sender_rank) {
+        send(REQUEST, pkt, role_to_pe["gateway"]);
+    }
+    void process_response(packet pkt, int sender_rank) {
+        std::cout<<"Client recieved response from PE"<<sender_rank<<std::endl;
+        std::cout<<"...should terminate here..."<<std::endl;
+        initiate_global_done();
+    }
+    public:
+    void start() {
+        std::cout<<"Client started"<<std::endl;
+        hclib::Selector<2, packet>::start();
+    }
+    ClientActor() {
+        std::cout<<"PE"<<shmem_my_pe()<<": ClientActor initialized"<<std::endl;
+        mb[REQUEST].process = [this](packet pkt, int sender_rank) { this->process_request(pkt, sender_rank);};
+        mb[REPLY].process = [this](packet pkt, int sender_rank) { this->process_response(pkt, sender_rank);};
+    }
+};
+
+class ServiceActor: public hclib::Selector<2, packet> {
+    void process_request(packet pkt, int sender_rank) {
+        std::cout<<"(request) Service received request from PE"<<sender_rank<<std::endl;
+        send(REPLY, pkt, shmem_my_pe());
+    }
+    void process_reply(packet pkt, int sender_rank) {
+        std::cout<<"(reply) Service received request from PE"<<role_to_pe["gateway"]<<std::endl;
+        send(REPLY, pkt, role_to_pe["gateway"]);
+    }
+    public:
+    void start() {
+        std::cout<<"Service started"<<std::endl;
+        hclib::Selector<2, packet>::start();
+    }
+    ServiceActor() {
+        std::cout<<"PE"<<shmem_my_pe()<<": ServiceActor initialized"<<std::endl;
+        mb[REQUEST].process = [this](packet pkt, int sender_rank) { this->process_request(pkt, sender_rank);};
+        mb[REPLY].process = [this](packet pkt, int sender_rank) { this->process_reply(pkt, sender_rank);};
+    }
+};
+
+// SPMD
+int main(int argc, char * argv[]) {
+  // Initialize SHMEM
+  // shmem_init();
+
+  const char *deps[] = { "system", "bale_actor" };
+  hclib::launch(deps, 2, [=] {
+    std::cout<<"Starting with "<<shmem_n_pes()<<" PEs"<<std::endl;
+    hclib::Selector<2, packet>* current_actor;
+    switch(shmem_my_pe()) {
+        case 0:
+            current_actor = new ClientActor();
+            break;
+        case 1:
+            current_actor = new GatewayActor();
+            break;
+        case 2:
+            current_actor = new ServiceActor();
+            break;
+    }
+    shmem_barrier_all();
+    hclib::finish([=]() {
+        
+        current_actor->start();
+        if (shmem_my_pe() == role_to_pe["client"]) {
+            packet pkt;
+            pkt.id = 1;
+            pkt.dest = role_to_pe["service_A"];
+            pkt.src = role_to_pe["client"];
+            current_actor->send(REQUEST, pkt, shmem_my_pe()); //dummy message so can have (outside) -> PE0 mb[REQUEST] 
+        }
+        //if (shmem_my_pe() == 0) {
+        //    current_actor->done(REQUEST);
+        //}
+    });
+    shmem_barrier_all();
+  });
+  // Finalize SHMEM
+  // shmem_finalize();
+  return 0;
+}

--- a/modules/bale_actor/test/randperm_selector.cpp
+++ b/modules/bale_actor/test/randperm_selector.cpp
@@ -41,6 +41,7 @@ extern "C" {
 #include <spmat.h>
 }
 #include "selector.h"
+#include <tuple>
 
 #define THREADS shmem_n_pes()
 #define MYTHREAD shmem_my_pe()
@@ -92,6 +93,14 @@ typedef struct pkg_t {
 enum PhaseOneMailBoxType {THROW, REPLY};
 enum PhaseTwoMailBoxType {MSG};
 
+/*
+    Throw a dart
+*/
+std::tuple<pkg_t, int64_t> throw_dart(int64_t* lperm, int64_t* iendPtr, int64_t M) {
+    int64_t r = lrand48() % M;
+    return {{r / THREADS, lperm[*iendPtr]}, r % THREADS};
+}
+
 class RandPermSelectorPhaseOne: public hclib::Selector<2, RPpkg> {
 public:
     RandPermSelectorPhaseOne(
@@ -99,8 +108,9 @@ public:
         int64_t* lperm,
         int64_t* iend,
         int64_t* hits,
-        int64_t lN
-    ) : ltarget_(ltarget), lperm_(lperm), iend_(iend), hits_(hits), lN_(lN) {
+        int64_t lN,
+        int64_t M
+    ) : ltarget_(ltarget), lperm_(lperm), iend_(iend), hits_(hits), lN_(lN), M_(M) {
         mb[THROW].process = [this](RPpkg pkg, int senderRank) { this->throwProcess(pkg, senderRank); };
         mb[REPLY].process = [this](RPpkg pkg, int senderRank) { this->replyProcess(pkg, senderRank); };
     }
@@ -111,6 +121,7 @@ private:
     int64_t* iend_;
     int64_t* hits_;
     int64_t lN_;
+    int64_t M_;
 
     void throwProcess(RPpkg pkg, int senderRank) {
         if (ltarget_[pkg.idx] == -1L) {
@@ -127,11 +138,15 @@ private:
 
     void replyProcess(RPpkg pkg, int senderRank) {
         if (pkg.idx < 0L) {
+            // dart does not hit: update and throw another dart
             lperm_[--(*iend_)] = -(pkg.idx) - 1;
+            auto [pkg, pe] = throw_dart(lperm_, iend_, M_);
+            send(THROW, pkg, pe);
         } else {
             (*hits_)++;
         }
-        printf("hits is %d, lN_ is %d\n", *hits_, lN_);
+        
+        // globally terminate once we've reached the required hits
         if (*hits_ >= lN_) { initiate_global_done(); }
     }
 };
@@ -149,7 +164,6 @@ private:
         lperm_[pos_++] = val;
     }
 };
-
 
 int64_t* copied_rand_permp_selector(int64_t N, int seed) {
     int64_t lN = (N + THREADS - MYTHREAD - 1) / THREADS;
@@ -179,48 +193,23 @@ int64_t* copied_rand_permp_selector(int64_t N, int seed) {
     int64_t* hitsPtr = &hits;
     int64_t* iendPtr = &iend;
 
-    RandPermSelectorPhaseOne* phaseOneSelector = new RandPermSelectorPhaseOne(ltarget, lperm, iendPtr, hitsPtr, lN);
+    RandPermSelectorPhaseOne* phaseOneSelector = new RandPermSelectorPhaseOne(ltarget, lperm, iendPtr, hitsPtr, lN, M);
     
     // setup finish, start algorithm
     lgp_barrier();
     double t1 = wall_seconds();
 
     hclib::finish([lN, M, lperm, hitsPtr, iendPtr, phaseOneSelector]() {
-        phaseOneSelector->mb[THROW].set_is_early_exit(true);
+        // phaseOneSelector->mb[THROW].set_is_early_exit(true);
         phaseOneSelector->start();
-        pkg_t pkg;
-        //int64_t i = 0;
 
-        // Since a throw a fail, we need to keep track of hits
-        // instead of believing our lN request will all result in hits
-        while (*hitsPtr != lN) {
-            //i = *iendPtr;
-
-            while (*iendPtr < lN) {
-                int64_t r = lrand48() % M;
-                int64_t pe = r % THREADS;
-                pkg.idx = r / THREADS;
-                pkg.val = lperm[*iendPtr];
-
-                bool ret = phaseOneSelector->send(THROW, pkg, pe);
-                //i++;
-
-                if(ret)
-                    (*iendPtr)++;
-                else
-                    hclib::yield();
-
-            }
-
-            //*iendPtr = i;
-
-            // // let the mailbox process in order for hits to update
-            // hclib::yield();
-
-            // // If enough hits are processed, break and teardown
-            // if (*hitsPtr >= lN) { break; }
-        }
-        // phaseOneSelector->done(THROW);
+        // throw initial set of darts,
+        //   then continue THROW - REPLY process through message handlers
+        while (*iendPtr < lN) {
+            auto [pkg, pe] = throw_dart(lperm, iendPtr, M); 
+            phaseOneSelector->send(THROW, pkg, pe);
+            (*iendPtr)++;
+        } 
     });
 
     lgp_barrier();


### PR DESCRIPTION
Due to SPMD execution, the `selector->done(mb_id)` will terminate `mb_id` mailbox and all dependencies ONLY on the caller PE (`shmem_my_pe()`). Some applications require a global termination protocol, such as when a PE signals that all PEs should now terminate OR when a PE signals its done working and will wait for all PEs global termination, which is not inherently supported due to the "local" SPMD termination process. 

There is a hacky workaround which requires an additional termination mailbox, polling, and a broadcast to all PEs. 

This PR adds two functionalities:

-  `selector->global_done()` API that, is invoked by the PE that "signals" termination of all PEs, will terminate all the mailboxes on **ALL** PEs. This should only be invoked in applications where a single PE knows when to terminate the whole execution, e.g. cloud apps. (see example `microtest_global_done_selector.cpp`)
- `selector->initiate_global_done()` API that is invoked by each PE to signal that it is done with all its work. From that point, it will only receive and process messages (and send additional messages if the request requires that). A global termination will be done automatically when the **final** PE invokes the API. Hence, each PE is required to call this API when it is done with its work, and the automatic global termination is handled by the backend. (see example `microtest_initiate_local_done_selector.cpp`)

Global termination can also be used to remove invocations of `hclib::yield()` in applications that require a context switch for real-time variable updates (e.g. randperm).