### PR TITLE
Adding support for complex dependencies and global termination

### DIFF
--- a/modules/bale_actor/inc/selector.h
+++ b/modules/bale_actor/inc/selector.h
@@ -2,8 +2,8 @@
 #ifndef SELECTOR_H
 #define SELECTOR_H
 
-#include<iostream>
-#include<vector>
+#include <iostream>
+#include <vector>
 #include "safe_buffer.h"
 #include "hclib_bale_actor.h"
 extern "C" {
@@ -22,6 +22,11 @@ extern "C" {
 #endif
 
 namespace hclib {
+
+#include "shmem.h"
+int *GLOBAL_DONE;
+int *LOCAL_DONE;
+
 #ifdef ENABLE_TCOMM_PROFILING
 #ifdef ENABLE_TRACE
 #error ENABLE_TRACE cannot be used with ENABLE_TCOMM_PROFILING so far
@@ -44,12 +49,6 @@ static inline uint64_t stop_tsc() {
 //PEtoNodeMap will be used for tracing purpose when ENABLE_TRACE is defined
 #ifdef ENABLE_TRACE
 #include<papi.h>
-
-#ifndef USE_SHMEM
-#error "Trace generation can be used only when USE_SHMEM=1"
-#else
-#include "shmem.h"
-#endif
 
 FILE *get_trace_fptr(bool is_new, const char name[] = "") {
     static FILE *fptr = NULL;
@@ -323,6 +322,10 @@ class Mailbox {
     bool is_early_exit = false, is_done = false;
     Mailbox* dep_mb = nullptr;
     int mb_id;
+    std::vector<int> dep_mbs;
+    int predecessor_mbs_count = 0;
+    bool is_cyclic = false;
+    bool done_called = false;
 #ifdef ENABLE_TRACE
     PapiTracer *papi_tracer = NULL;
 #endif
@@ -368,6 +371,44 @@ class Mailbox {
 
     Mailbox* get_dep_mb() {
         return dep_mb;
+    }
+
+    void set_is_cyclic(bool val) {
+        is_cyclic = val;
+    }
+
+    bool get_is_cyclic() {
+        return is_cyclic;
+    }
+
+    void set_done_called(bool val) {
+        done_called = val;
+    }
+
+    bool get_done_called() {
+        return done_called;
+    }
+
+    void add_dep_mbs(std::vector<int> successor_mbs) {
+        for (int64_t const& successor_mb_id : successor_mbs) {
+            dep_mbs.push_back(successor_mb_id);
+        }
+    }
+
+    std::vector<int> get_dep_mbs() {
+        return dep_mbs;
+    }
+
+    int64_t get_predecessor_mbs_count() {
+        return predecessor_mbs_count;
+    }
+
+    void inc_predecessor_mbs_count() {
+        predecessor_mbs_count++;
+    }
+
+    void dec_predecessor_mbs_count() {
+        predecessor_mbs_count--;
     }
 
 #ifdef ENABLE_TRACE
@@ -461,12 +502,12 @@ class Mailbox {
 
           //Assumes once 'advance' is called with done=true, the conveyor
           //enters endgame and subsequent value of 'done' is ignored
-          while(convey_advance(conv, bp.rank == DONE_MARK)) {
+          while(convey_advance(conv, bp.rank == DONE_MARK || *GLOBAL_DONE == -1)) {
               int i;
               size_t buff_size = buff->size();
               for(i=0;i<buff_size; i++){
                   bp = buff->operator[](i);
-                  if( bp.rank == DONE_MARK) break;
+                  if( bp.rank == DONE_MARK || *GLOBAL_DONE == -1 ) break;
 #ifdef USE_LAMBDA
                   //printf("size %d\n", bp.lambda_pkt->get_bytes());
                   if( !convey_epush(conv, bp.lambda_pkt->get_bytes(), bp.lambda_pkt, bp.rank)) break;
@@ -544,12 +585,12 @@ class Mailbox {
 
           //Assumes once 'advance' is called with done=true, the conveyor
           //enters endgame and subsequent value of 'done' is ignored
-          while(convey_advance(conv, bp.rank == DONE_MARK)) {
+          while(convey_advance(conv, bp.rank == DONE_MARK || *GLOBAL_DONE == -1)) {
               int i;
               size_t buff_size = buff->size();
               for(i=0;i<buff_size; i++){
                   bp = buff->operator[](i);
-                  if( bp.rank == DONE_MARK) break;
+                  if( bp.rank == DONE_MARK || *GLOBAL_DONE == -1 ) break;
 #ifdef USE_LAMBDA
                   //printf("size %d\n", bp.lambda_pkt->get_bytes());
                   if( !convey_epush(conv, bp.lambda_pkt->get_bytes(), bp.lambda_pkt, bp.rank)) break;
@@ -603,6 +644,23 @@ template<int N, typename T=int64_t, int SIZE=BUFFER_SIZE>
 class Selector {
 
   private:
+    void initialize_local_global_done() {
+        GLOBAL_DONE = (int*)shmem_malloc(sizeof(int));
+        LOCAL_DONE = (int*)shmem_malloc(sizeof(int));
+
+        if(GLOBAL_DONE==NULL){
+            std::cout << "ERROR: Unable to allocate space for GLOBAL_DONE pointer\n" << std::endl;
+            abort();
+        }
+        if(LOCAL_DONE==NULL){
+            std::cout << "ERROR: Unable to allocate space for LOCAL_DONE pointer\n" << std::endl;
+            abort();
+        }
+
+        *GLOBAL_DONE = 0;
+        *LOCAL_DONE = 0;
+    }
+
 #ifdef ENABLE_TRACE
     void createPEtoNodeMap() {
         PEtoNodeMap = (int*)shmem_malloc(shmem_n_pes()*sizeof(int));
@@ -683,6 +741,7 @@ class Selector {
         #ifdef ENABLE_TRACE
         createPEtoNodeMap();
         #endif
+        initialize_local_global_done();
         if(is_start) {
             start();
         }
@@ -712,9 +771,29 @@ class Selector {
 #endif
         }
         start_worker_loop();
+
+        // check if mailbox has cyclic dependency
+        for(int mb_id = 0; mb_id < N; mb_id++) {
+            check_cyclic(mb_id);
+        }
+
 #ifdef ENABLE_TRACE
         papi_tracer.start();
 #endif
+    }
+
+    void check_cyclic(int mb_id) {
+        std::vector<int> successors_mb = mb[mb_id].get_dep_mbs();
+
+        for (int const& successor_mb_id : successors_mb) {
+            mb[successor_mb_id].inc_predecessor_mbs_count();
+
+            if (successor_mb_id == mb_id) {
+                mb[mb_id].set_is_cyclic(true);
+            } else {
+                check_cyclic(successor_mb_id);  // recursively check successors
+            }
+        }
     }
 
 #ifdef USE_LAMBDA
@@ -779,6 +858,42 @@ class Selector {
     }
 #endif // USE_LAMBDA
 
+    void initiate_global_done() { // signals current PE termination
+        // need extra layer with LOCAL_DONE because some apps require mbs to send messages
+        //  within the "request" that they are serving, so this keeps the mb active to do that
+
+        *LOCAL_DONE = -1; 
+
+        int global_done_flag = 0;
+        int local_done_value;
+
+        // fetch LOCAL_DONE on all PEs
+        for (int pe_id = 0; pe_id < shmem_n_pes(); pe_id++) {
+            if (pe_id == shmem_my_pe()) {
+                local_done_value = *LOCAL_DONE;
+            } else {
+                local_done_value = shmem_int_g(LOCAL_DONE, pe_id);
+            }
+            if (!local_done_value) { break; }
+            global_done_flag += local_done_value;
+        }
+
+        // if all LOCAL_DONE == (-1)*shmem_n_pes then can (safely) invoke global termination
+        if (global_done_flag == (-1 * shmem_n_pes())) {
+            global_done();
+        }
+    }
+
+    void global_done() { // invokes global termination on all PEs
+        for (int pe_id = 0; pe_id < shmem_n_pes(); pe_id++) {
+            if (pe_id == shmem_my_pe()) {
+                *GLOBAL_DONE = -1;
+            } else {
+                shmem_int_p(GLOBAL_DONE, -1, pe_id);
+            }
+        }
+    }
+
     void done(int mb_id) {
 #ifdef ENABLE_TRACE
         if (mb_id == 0)
@@ -808,6 +923,35 @@ class Selector {
 #endif
             }
         }, mb[mb_id].get_worker_loop_finish(), nic);
+    }
+
+    void done_extended(int mb_id) {
+        bool mb_cyclic = mb[mb_id].get_is_cyclic();
+        bool mb_done_called;
+        if (mb_cyclic) mb_done_called = mb[mb_id].get_done_called();
+
+        // only call done on acyclic mb or cyclic mb that has not already received done(mb)
+        if ((!mb_cyclic) || (mb_cyclic && !mb_done_called)) {
+            mb[mb_id].done();
+            if (mb_cyclic) mb[mb_id].set_done_called(true);
+            hclib::async_await_at([=]() {
+                num_work_loop_end++;
+
+                std::vector<int> successor_mbs = mb[mb_id].get_dep_mbs();
+                for (int const& successor_mb_id : successor_mbs) {
+                    int num_predecessors = mb[successor_mb_id].get_predecessor_mbs_count();
+                    if (num_predecessors == 1) {
+                        done_extended(successor_mb_id);
+                    } else {
+                        mb[successor_mb_id].dec_predecessor_mbs_count();
+                    }
+                }
+                
+                if (num_work_loop_end == N) {
+                    end_prom.put(1);
+                }
+            }, mb[mb_id].get_worker_loop_finish(), nic);
+        }
     }
 
     void done() {

--- a/modules/bale_actor/inc/selector.h
+++ b/modules/bale_actor/inc/selector.h
@@ -23,7 +23,12 @@ extern "C" {
 
 namespace hclib {
 
+#ifndef USE_SHMEM
+#error "Extended complex termination protocols (done_extended and global_done) can be used only when USE_SHMEM=1"
+#else
 #include "shmem.h"
+#endif
+
 int *GLOBAL_DONE;
 int *LOCAL_DONE;
 

--- a/modules/bale_actor/test/Makefile
+++ b/modules/bale_actor/test/Makefile
@@ -4,12 +4,13 @@ include $(HCLIB_ROOT)/../modules/bale_actor/inc/hclib_bale_actor.post.mak
 
 SRUN ?= oshrun
 
-TARGETS=test_conveyor test_selector test_selector3 \
+TARGETS=dependency_cyclic_selector factorial_selector \
+	test_conveyor test_selector test_selector3 \
         histo_agi histo_conveyor histo_selector histo_selector_lambda histo_selector_lambda2  histo_agi_selector\
         ig_agi ig_conveyor ig_selector ig_selector_lambda ig_selector_lambda2 ig_agi_selector\
         toposort_agi toposort_conveyor toposort_selector toposort_selector_lambda \
         triangle_agi triangle_conveyor triangle_selector triangle_selector_lambda\
-        randperm_agi randperm_conveyor randperm_selector randperm_selector_lambda \
+        randperm_agi randperm_conveyor randperm_selector randperm_globaldone_selector randperm_selector_lambda \
         permute_agi permute_conveyor permute_selector permute_selector_lambda \
         transpose_agi transpose_conveyor transpose_selector transpose_selector_lambda \
         put_selector_shmem put_nbi_shmem \

--- a/modules/bale_actor/test/dependency_cyclic_selector.cpp
+++ b/modules/bale_actor/test/dependency_cyclic_selector.cpp
@@ -1,0 +1,156 @@
+/******************************************************************
+//
+// 
+ *****************************************************************/ 
+/*! \file dependancy_cylic_selector.cpp
+ * \brief Demo application for graph termination dependancies (with complex cyclic/acyclic dependencies and cycles). 
+ *
+ */
+
+#include <math.h>
+#include <shmem.h>
+extern "C" {
+#include "spmat.h"
+}
+#include "selector.h"
+
+#define THREADS shmem_n_pes()
+#define MYTHREAD shmem_my_pe()
+
+enum MailBoxType {A, B, C, D, E};
+
+typedef struct DepPkt {
+    int64_t i;
+} DepPkt;
+
+class DepSelector: public hclib::Selector<5, DepPkt> {
+public:
+    DepSelector(int64_t* sum_arr) : sum_arr_(sum_arr) {
+        mb[A].process = [this] (DepPkt pkt, int sender_rank) { 
+            this->a_process(pkt, sender_rank);
+        }; 
+        mb[A].add_dep_mbs({B,D}); // successors = {B,D}
+
+        mb[B].process = [this] (DepPkt pkt, int sender_rank) { 
+            this->b_process(pkt, sender_rank);
+        };
+        mb[B].add_dep_mbs({}); // successors = {}
+        
+        mb[C].process = [this] (DepPkt pkt, int sender_rank) { 
+            this->c_process(pkt, sender_rank);
+        };
+        mb[C].add_dep_mbs({D,E}); // successors = {D,E}
+
+        mb[D].process = [this] (DepPkt pkt, int sender_rank) { 
+            this->d_process(pkt, sender_rank);
+        };
+        mb[D].add_dep_mbs({}); // successors = {}
+
+        mb[E].process = [this] (DepPkt pkt, int sender_rank) { 
+            this->e_process(pkt, sender_rank);
+        };
+        mb[E].add_dep_mbs({}); // successors = {}
+    }
+
+private:
+    //shared variables
+    int64_t* sum_arr_;
+    int counter = 0;
+
+    void a_process(DepPkt pkg, int sender_rank) {
+        sum_arr_[0] = counter;
+        counter++;
+        send(B, pkg, sender_rank);
+        printf("sending message to mailbox B ...\n");
+        send(D, pkg, sender_rank);
+        printf("sending message to mailbox D ...\n");
+        send(A, pkg, sender_rank);
+        printf("sending message to mailbox A ...\n"); //cyclic
+        if (counter == 5) {
+            done_extended(A);
+        }
+    }
+
+    void b_process(DepPkt pkg, int sender_rank) {
+        sum_arr_[1] = MYTHREAD;
+    }
+    
+    void c_process(DepPkt pkg, int sender_rank) {
+        sum_arr_[2] = MYTHREAD;
+        send(D, pkg, sender_rank);
+        printf("sending message to mailbox D ...\n");
+        send(E, pkg, sender_rank);
+        printf("sending message to mailbox E ...\n");
+    }
+
+    void d_process(DepPkt pkg, int sender_rank) {
+        sum_arr_[3] = MYTHREAD;
+    }
+
+    void e_process(DepPkt pkg, int sender_rank) {
+        sum_arr_[4] = MYTHREAD;
+    }
+    
+};
+
+int main(int argc, char* argv[]) {
+    const char *deps[] = { "system", "bale_actor" };
+
+    hclib::launch(deps, 2, [=] {
+
+        int64_t* sum_arr = (int64_t*)lgp_all_alloc(5, sizeof(int64_t));
+        for (int64_t x = 0; x < 5; x++) sum_arr[x] = 0;
+
+        printf("\n\n");
+        printf("Initial array contents: ");
+        for (int64_t x = 0; x < 5; x++) printf("%d ", sum_arr[x]);
+        printf("\n                        A B C D E");
+        printf("\n\n");
+
+        DepSelector* depSelector = new DepSelector(sum_arr);
+
+        hclib::finish([=]() {
+            depSelector->start();
+            DepPkt pkg;
+            pkg.i = 0;
+
+            /* ---------------------------- */
+            /*      DEPENDANCY GRAPH:       */
+            //           ----
+            //           ˅  |
+            //          A   -->   B
+            //              \
+            //               \
+            //                >
+            //          C   -->   D
+            //              \
+            //               \
+            //                 >  E
+            /* ---------------------------- */
+
+            // send to mailbox A        (A -> B)
+            printf("sending message to mailbox A ...\n");
+            depSelector->send(A, pkg, MYTHREAD);
+
+            // send to mailbox C        (C -> D       C -> E)
+            printf("sending message to mailbox C ...\n");
+            depSelector->send(C, pkg, MYTHREAD);
+
+            // invoke done on mailbox A and C
+            depSelector->done_extended(C);
+        });
+
+        printf("\n\n");
+        printf("Final array contents: ");
+        for (int64_t x = 0; x < 5; x++) printf("%d ", sum_arr[x]);
+        printf("\n                      A B C D E");
+        printf("\n\n");
+
+        lgp_barrier();
+
+        lgp_finalize();
+
+    });
+
+    return 0;
+}

--- a/modules/bale_actor/test/factorial_selector.cpp
+++ b/modules/bale_actor/test/factorial_selector.cpp
@@ -1,0 +1,87 @@
+/******************************************************************
+//
+// 
+ *****************************************************************/ 
+/*! \file factorial_selector.cpp
+ * \brief Demo application for graph termination dependancies. 
+ *          Calculate the factorial of a randomly generated number from 1 to 10
+ *
+ */
+
+#include <math.h>
+#include <shmem.h>
+extern "C" {
+#include "spmat.h"
+}
+#include "selector.h"
+#include <cstdlib>
+#include <iostream>
+using namespace std;
+
+#define THREADS shmem_n_pes()
+#define MYTHREAD shmem_my_pe()
+
+enum MailBoxType {A};
+
+typedef struct DepPkt {
+    int64_t n;
+    int64_t index;
+} DepPkt;
+
+class DepSelector: public hclib::Selector<1, DepPkt> {
+public:
+    DepSelector(int64_t* factorial) : factorial_(factorial) {
+        mb[A].process = [this] (DepPkt pkt, int sender_rank) { 
+            this->a_process(pkt, sender_rank);
+        };
+        mb[A].add_dep_mbs({A}); // successors = {A}
+    }
+
+private:
+    //shared variables
+    int64_t* factorial_;
+
+    void a_process(DepPkt pkg, int sender_rank) {
+        if ((pkg.n == 0) || (pkg.n == 1)) {
+            *factorial_ *= 1;
+            done_extended(A);
+        } else {*factorial_ *= pkg.n;}
+        DepPkt next_pkg;
+        next_pkg.n = pkg.n - 1;
+        send(A, next_pkg, sender_rank);
+    }
+};
+
+int main(int argc, char* argv[]) {
+    const char *deps[] = { "system", "bale_actor" };
+
+    hclib::launch(deps, 2, [=] {
+
+        //srand(time(0)); 
+
+        T0_fprintf(stderr, "\n\nFactorial of a randomly generated number between 1 and 10 (selector)...\n");
+
+        int64_t num_input = 1+ (rand() % 10);
+
+        int64_t factorial = 1;
+
+        DepSelector* depSelector = new DepSelector(&factorial);
+
+        hclib::finish([=]() {
+            depSelector->start();
+            DepPkt pkg;
+            pkg.n = num_input;
+            depSelector->send(A, pkg, MYTHREAD);
+        });
+
+        lgp_barrier();
+
+        printf("\n[PE %d] FACTORIAL OF %d IS (%d!): %d", MYTHREAD, num_input, num_input, factorial);
+        printf("\n");
+
+        lgp_finalize();
+
+    });
+
+    return 0;
+}

--- a/modules/bale_actor/test/randperm_globaldone_selector.cpp
+++ b/modules/bale_actor/test/randperm_globaldone_selector.cpp
@@ -1,0 +1,335 @@
+/******************************************************************
+//
+//
+//  Copyright(C) 2018, Institute for Defense Analyses
+//  4850 Mark Center Drive, Alexandria, VA; 703-845-2500
+//  This material may be reproduced by or for the US Government
+//  pursuant to the copyright license under the clauses at DFARS
+//  252.227-7013 and 252.227-7014.
+// 
+//
+//  All rights reserved.
+//  
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are met:
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//    * Neither the name of the copyright holder nor the
+//      names of its contributors may be used to endorse or promote products
+//      derived from this software without specific prior written permission.
+// 
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+//  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+//  COPYRIGHT HOLDER NOR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+//  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+//  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+//  HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+//  STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+//  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+//  OF THE POSSIBILITY OF SUCH DAMAGE.
+// 
+ *****************************************************************/ 
+
+#include <shmem.h>
+extern "C" {
+#include <spmat.h>
+}
+#include "selector.h"
+#include <tuple>
+
+#define THREADS shmem_n_pes()
+#define MYTHREAD shmem_my_pe()
+
+/*! \file randperm_selector.cpp
+ * \brief Demo program that runs the variants of randperm kernel. This program
+ * generates a random permutation in parallel.
+ */
+
+/*! 
+\page randperm_page Random Permutation
+
+Demo program that runs the variants of randperm kernel. This program
+generates a random permutation in parallel. The algorithm used is the 
+"dart throwing algorithm" found in 
+ P.B.Gibbon, Y.Matias, and V.L.Ramachandran. Efficient low-contention Parallel algorithms.
+ J. of Computer and System Sciences, 53:417-442, Dec 1992.
+
+Interestingly, we discovered what looks to be a superior and simpler algorithm. This is implemented
+in alternates/randperm_agi_opt.upc.
+
+See files spmat_agi.upc, spmat_exstack.upc, spmat_exstack2.upc, and spmat_conveyor.upc
+for the source for the kernels.
+
+Usage:
+randperm [-h][-n num][-M mask][-s seed]
+- -h Print usage banner only
+- -b count is the number of packages in an exstack(2) buffer
+- -n=num Set the permutation entries per PE to n (default = 1000).
+- -M=mask Set the models mask (1,2,4,8,16,32 for AGI,exstack,exstack2,conveyor,alternate)
+- -s=seed Set a seed for the random number generation.
+ */
+
+/*
+    Regular Benchmark stuff starts here
+*/
+typedef struct pkg_t {
+    int64_t idx; 
+    int64_t val;
+} RPpkg;
+
+/*
+    In the original code the reply packet is just int64_t,
+    since Hclib Selector doesn't support different mailboxes of different
+    packet type, the reply packge will have idx field = data, val should 
+    always 0
+*/
+
+enum PhaseOneMailBoxType {THROW, REPLY};
+enum PhaseTwoMailBoxType {MSG};
+
+/*
+    Throw a dart
+*/
+std::tuple<pkg_t, int64_t> throw_dart(int64_t* lperm, int64_t* iendPtr, int64_t M) {
+    int64_t r = lrand48() % M;
+    return {{r / THREADS, lperm[*iendPtr]}, r % THREADS};
+}
+
+class RandPermSelectorPhaseOne: public hclib::Selector<2, RPpkg> {
+public:
+    RandPermSelectorPhaseOne(
+        int64_t* ltarget,
+        int64_t* lperm,
+        int64_t* iend,
+        int64_t* hits,
+        int64_t lN,
+        int64_t M
+    ) : ltarget_(ltarget), lperm_(lperm), iend_(iend), hits_(hits), lN_(lN), M_(M) {
+        mb[THROW].process = [this](RPpkg pkg, int senderRank) { this->throwProcess(pkg, senderRank); };
+        mb[REPLY].process = [this](RPpkg pkg, int senderRank) { this->replyProcess(pkg, senderRank); };
+    }
+
+private:
+    int64_t* ltarget_;
+    int64_t* lperm_;
+    int64_t* iend_;
+    int64_t* hits_;
+    int64_t lN_;
+    int64_t M_;
+
+    void throwProcess(RPpkg pkg, int senderRank) {
+        if (ltarget_[pkg.idx] == -1L) {
+            int64_t val = pkg.val;
+
+            send(REPLY, RPpkg{val, 0}, senderRank);
+            ltarget_[pkg.idx] = pkg.val;
+        } else {
+            int64_t val = -(pkg.val + 1);
+
+            send(REPLY, RPpkg{val, 0}, senderRank);
+        }
+    }
+
+    void replyProcess(RPpkg pkg, int senderRank) {
+        if (pkg.idx < 0L) {
+            // dart does not hit: update and throw another dart
+            lperm_[--(*iend_)] = -(pkg.idx) - 1;
+            auto [pkg, pe] = throw_dart(lperm_, iend_, M_);
+            send(THROW, pkg, pe);
+        } else {
+            (*hits_)++;
+        }
+        
+        // globally terminate once we've reached the required hits
+        if (*hits_ >= lN_) { initiate_global_done(); }
+    }
+};
+
+class RandPermSelectorPhaseTwo: public hclib::Selector<1, int64_t> {
+public:
+    RandPermSelectorPhaseTwo(int64_t* lperm, int64_t& pos) : lperm_(lperm), pos_(pos) {
+        mb[MSG].process = [this](int64_t pkg, int senderRank) { this->processMsg(pkg, senderRank); };
+    }
+private:
+    int64_t* lperm_;
+    int64_t& pos_;
+
+    void processMsg(int64_t val, int senderRank) {
+        lperm_[pos_++] = val;
+    }
+};
+
+int64_t* copied_rand_permp_selector(int64_t N, int seed) {
+    int64_t lN = (N + THREADS - MYTHREAD - 1) / THREADS;
+    int64_t M = N * 2;
+    int64_t lM = (M + THREADS - MYTHREAD - 1) / THREADS;
+
+    int64_t* perm = (int64_t*)lgp_all_alloc(N, sizeof(int64_t));
+    if (!perm) return nullptr;
+    int64_t* lperm = lgp_local_part(int64_t, perm);
+
+    int64_t* target = (int64_t*)lgp_all_alloc(M, sizeof(int64_t));
+    if (!target) return nullptr;
+    int64_t* ltarget = lgp_local_part(int64_t, target);;
+  
+    /* initialize perm[i] = i,  the darts*/
+    for (int64_t i = 0; i < lN; i++)
+        lperm[i] = i * THREADS + MYTHREAD;
+
+    /* initialize target[i] = -1 */
+    for (int64_t i = 0; i < lM; i++)
+        ltarget[i] = -1L;
+
+    if (seed != 0) srand48(seed);
+
+    int64_t hits = 0;
+    int64_t iend = 0;
+    int64_t* hitsPtr = &hits;
+    int64_t* iendPtr = &iend;
+
+    RandPermSelectorPhaseOne* phaseOneSelector = new RandPermSelectorPhaseOne(ltarget, lperm, iendPtr, hitsPtr, lN, M);
+    
+    // setup finish, start algorithm
+    lgp_barrier();
+    double t1 = wall_seconds();
+
+    hclib::finish([lN, M, lperm, hitsPtr, iendPtr, phaseOneSelector]() {
+        phaseOneSelector->start();
+
+        // throw initial set of darts,
+        //   then continue THROW - REPLY process through message handlers
+        while (*iendPtr < lN) {
+            auto [pkg, pe] = throw_dart(lperm, iendPtr, M); 
+            phaseOneSelector->send(THROW, pkg, pe);
+            (*iendPtr)++;
+        } 
+    });
+
+    lgp_barrier();
+    t1 = wall_seconds() - t1;
+    delete phaseOneSelector;
+
+    // T0_printf("phase 1 t1 = %8.3lf\n", t1);
+    // T0_printf("DEBUG: phase 1 finished, no task starving\n");
+
+    /* now locally pack the values you have in target */
+    int64_t cnt = 0;
+    for (int64_t i = 0; i < lM; i++) {
+        if (ltarget[i] != -1L) {
+            ltarget[cnt++] = ltarget[i];
+        }
+    }
+    lgp_barrier();
+  
+    /* sanity check */
+    int64_t total = lgp_reduce_add_l(cnt);
+    if (total != N) {
+        T0_printf("ERROR: rand_permp_selector: total = %ld should be %ld\n", total, N);
+
+        return nullptr;
+    }
+
+    int64_t offset = lgp_prior_add_l(cnt);
+    int64_t pos = 0;
+    RandPermSelectorPhaseTwo* phaseTwoSelector = new RandPermSelectorPhaseTwo(lperm, pos);
+
+    hclib::finish([phaseTwoSelector, cnt, offset, ltarget]() {
+        phaseTwoSelector->start();
+        int64_t i = 0;
+        int64_t pe = offset % THREADS;
+
+        while (i < cnt) {
+            phaseTwoSelector->send(MSG, ltarget[i], pe);
+
+            i++;
+            pe++;
+
+            if (pe == THREADS) pe = 0;
+        }
+
+        phaseTwoSelector->done(MSG);
+    });
+
+    pos = lgp_reduce_add_l(pos);
+    if (pos != N) {
+        printf("ERROR! in rand_permp_selector! sum of pos = %ld lN = %ld\n", pos, N);
+
+        return nullptr;
+    }
+
+    lgp_barrier();
+    delete phaseTwoSelector;
+
+    return perm;
+}
+
+int main(int argc, char* argv[]) {
+    const char *deps[] = { "system", "bale_actor" };
+    hclib::launch(deps, 2, [=] {
+        int64_t i;
+        int64_t models_mask = 0xF;
+        int printhelp = 0;
+        int64_t l_numrows = 1000000;
+        int64_t numrows;
+        int64_t buf_cnt = 1024;
+        int64_t seed = 101892 + MYTHREAD;
+        int64_t cores_per_node = 1;
+
+        int opt; 
+        while ((opt = getopt(argc, argv, "c:hn:M:s:")) != -1 ){
+            switch (opt) {
+                case 'h': printhelp = 1; break;
+                case 'b': sscanf(optarg,"%ld",&buf_cnt);  break;
+                case 'c': sscanf(optarg,"%ld" ,&cores_per_node); break;
+                case 'n': sscanf(optarg,"%ld",&l_numrows);   break;
+                case 'M': sscanf(optarg,"%ld",&models_mask);  break;
+                case 's': sscanf(optarg,"%ld", &seed); break;      
+                default:  break;
+            }
+        }
+
+        T0_fprintf(stderr, "Running randperm on %d threads\n", THREADS);
+        T0_fprintf(stderr, "This is a demo program that runs various implementations of the randperm kernel.\n");
+        T0_fprintf(stderr, "Usage:\n");
+        T0_fprintf(stderr, "Permutation size per thread (-n) = %ld\n", l_numrows);
+        T0_fprintf(stderr, "models_mask (-M)                 = %ld or of 1,2,4,8 for atomics,classic,exstack2,conveyor\n", models_mask);
+        T0_fprintf(stderr, "seed (-s)                        = %ld\n", seed);
+
+        numrows = l_numrows * THREADS;
+
+        double t1;
+        minavgmaxD_t stat[1];
+        int64_t error = 0;
+        int64_t* out;
+
+        int64_t use_model;
+  
+        T0_fprintf(stderr, "Running rand_permp_selector\n");
+        t1 = wall_seconds();
+        out = copied_rand_permp_selector(numrows, seed);
+        t1 = wall_seconds() - t1;
+        
+        T0_fprintf(stderr, "rand_permp_selector:           \n");
+        lgp_min_avg_max_d(stat, t1, THREADS);
+        T0_fprintf(stderr, " %8.3lf seconds\n", stat->avg);
+
+        if (!is_perm(out, numrows)) {
+            error++;
+            T0_printf("\nERROR: rand_permp_selector failed!\n\n");
+        }
+        lgp_all_free(out);
+  
+        if (error) {
+            T0_fprintf(stderr,"BALE FAIL!!!!\n"); 
+        }
+  
+    });
+
+    return 0;
+}


### PR DESCRIPTION
**Complex dependencies:**
HClib-Actor currently only supports linear acyclic mailbox dependencies. This PR extends support for complex (non-linear) acyclic dependencies and introduces support for non-complex/complex (linear/non-linear) cyclic dependencies.

**Global termination:**
Due to SPMD execution, the `selector->done(mb_id)` will terminate `mb_id` mailbox and all dependencies ONLY on the caller PE (`shmem_my_pe()`). Some applications require a global termination protocol, such as when a PE signals that all PEs should now terminate OR when a PE signals its done working and will wait for all PEs global termination, which is not inherently supported due to the "local" SPMD termination process. 

There is a hacky workaround which requires an additional termination mailbox, polling, and a broadcast to all PEs. 

This PR adds two functionalities:

-  `selector->global_done()` API that, is invoked by the PE that "signals" termination of all PEs, will terminate all the mailboxes on **ALL** PEs. This should only be invoked in applications where a single PE knows when to terminate the whole execution, e.g. cloud apps. (see example `microtest_global_done_selector.cpp`)
- `selector->initiate_global_done()` API that is invoked by each PE to signal that it is done with all its work. From that point, it will only receive and process messages (and send additional messages if the request requires that). A global termination will be done automatically when the **final** PE invokes the API. Hence, each PE is required to call this API when it is done with its work, and the automatic global termination is handled by the backend. (see example `microtest_initiate_local_done_selector.cpp`)

Global termination can also be used to remove invocations of `hclib::yield()` in applications that require a context switch for real-time variable updates (e.g. randperm).