### PR TITLE
Variadic-Mailbox

### DIFF
--- a/modules/bale_actor/inc/selector-mb.h
+++ b/modules/bale_actor/inc/selector-mb.h
@@ -1,0 +1,1044 @@
+#ifndef SELECTOR_H
+#define SELECTOR_H
+
+#include <iostream>
+#include <vector>
+#include <tuple>
+#include <inttypes.h>
+#include "safe_buffer.h"
+#include "hclib_bale_actor.h"
+extern "C" {
+#include "convey.h"
+}
+
+#ifndef NO_USE_BUFFER
+#define USE_BUFFER
+#endif
+
+// #define ENABLE_TRACE       /* Insert this line before including selector.h in user program */
+// #define ENABLE_TRACE_PAPI  /* Additionally insert this line to enable PAPI-based tracing  */
+#if defined(ENABLE_TRACE_PAPI) && !defined(ENABLE_TRACE)
+#define ENABLE_TRACE
+#endif
+
+#define DONE_MARK -1
+#define BUFFER_SIZE 1024
+#ifndef ELASTIC_BUFFER_SIZE
+#define ELASTIC_BUFFER_SIZE 128
+#endif
+
+namespace hclib {
+
+#ifndef USE_SHMEM
+#error "Extended complex termination protocols (done_extended and global_done) can be used only when USE_SHMEM=1"
+#else
+#include "shmem.h"
+#endif
+
+#ifdef ENABLE_TCOMM_PROFILING
+#ifdef ENABLE_TRACE
+#error ENABLE_TRACE cannot be used with ENABLE_TCOMM_PROFILING so far
+#endif
+static inline uint64_t _rdtsc(void) {
+    unsigned a, d;
+    asm volatile("rdtsc" : "=a" (a), "=d" (d) : : "%rbx", "%rcx");
+    return ((uint64_t) a) | (((uint64_t) d) << 32);
+}
+static inline uint64_t start_tsc() { return _rdtsc(); }
+static inline uint64_t stop_tsc() { return _rdtsc(); }
+#endif
+
+//PEtoNodeMap will be used for tracing purpose when ENABLE_TRACE is defined
+#ifdef ENABLE_TRACE
+#ifdef ENABLE_TRACE_PAPI
+#include <papi.h>
+#endif
+
+FILE *get_trace_fptr(bool is_new, const char name[] = "") {
+    static FILE *fptr = NULL;
+    if (fptr == NULL || is_new) {
+        char fname[256];
+        if (name != NULL && name[0] != '\0')
+            snprintf(fname, sizeof(fname), "PE%d_%s_send.csv", shmem_my_pe(), name);
+        else
+            snprintf(fname, sizeof(fname), "PE%d_send.csv", shmem_my_pe());
+        fptr = fopen(fname, "w");
+    }
+    return fptr;
+}
+
+#ifdef ENABLE_TRACE_PAPI
+FILE *get_papi_trace_fptr(bool is_new, const char name[] = "") {
+    static FILE *fptr = NULL;
+    if (fptr == NULL || is_new) {
+        char fname[256];
+        if (name != NULL && name[0] != '\0')
+            snprintf(fname, sizeof(fname), "PE%d_%s_PAPI.csv", shmem_my_pe(), name);
+        else
+            snprintf(fname, sizeof(fname), "PE%d_PAPI.csv", shmem_my_pe());
+        fptr = fopen(fname, "w");
+    }
+    return fptr;
+}
+#endif
+
+/*
+  Library function to create a new file for trace output, e.g.:
+    char name[32];
+    sprintf(name, "phase%d", 3);
+    hclib::new_file_for_selector_trace(name);
+    // Trace output is written to the file named "PE*_phase3_send.csv" and "PE*_phase3_PAPI.csv".
+ */
+void new_file_for_selector_trace(char name[]) {
+  FILE *fptr1 = get_trace_fptr(true, name);
+#ifdef ENABLE_TRACE_PAPI
+  FILE *fptr2 = get_papi_trace_fptr(true, name);
+#endif
+}
+
+double get_clock_time() {
+    struct timespec tv;
+    clock_gettime(CLOCK_REALTIME, &tv);
+    double stamp = (double)tv.tv_sec + (double)tv.tv_nsec / 1000000000L;
+    return stamp;
+}
+
+int *PEtoNodeMap;
+void trace_send(int64_t src, int64_t dst, size_t pkg_size) {
+    FILE *fptr = get_trace_fptr(false);
+    double stamp = get_clock_time();
+    fprintf(fptr, "%d, %ld, %d, %ld, %ld, %lf\n", PEtoNodeMap[src], src, PEtoNodeMap[dst], dst, pkg_size, stamp);
+    fflush(fptr);
+}
+
+#ifdef ENABLE_TRACE_PAPI
+/*
+  Future work: Allows user to specify the PAPI events to be measured.
+ */
+const char* papi_events[3] = {"PAPI_TOT_CYC", "PAPI_TOT_INS", "PAPI_LST_INS"};
+int papi_num_events = 3;
+long long papi_tmp_counts[3];
+
+int papi_eventset;
+int HCLIB_PAPI_Init() {
+    int retval;
+    retval = PAPI_library_init(PAPI_VER_CURRENT);
+    if (retval != PAPI_VER_CURRENT) {
+        fprintf(stderr,"Error initializing PAPI! %s\n",
+                PAPI_strerror(retval));
+        return 0;
+    }
+    papi_eventset = PAPI_NULL;
+
+    retval = PAPI_create_eventset(&papi_eventset);
+    if (retval != PAPI_OK) {
+        fprintf(stderr,"Error creating eventset! %s\n",
+                PAPI_strerror(retval));
+    }
+    for (int i = 0; i < papi_num_events; i++) {
+        retval = PAPI_add_named_event(papi_eventset, papi_events[i]);
+        if (retval != PAPI_OK) {
+            fprintf(stderr,"Error adding %s: %s\n",
+                    papi_events[i],
+                    PAPI_strerror(retval));
+        }
+    }
+    return 0;
+}
+
+void inline HCLIB_PAPI_Start() {
+    int retval;
+    PAPI_reset(papi_eventset);
+    retval = PAPI_start(papi_eventset);
+    if (retval != PAPI_OK) {
+        fprintf(stderr,"Error starting PAPI: %s\n",
+                PAPI_strerror(retval));
+    }
+}
+
+void inline HCLIB_PAPI_Stop(long long *counters, bool accum = true) {
+    int retval;
+    retval = PAPI_stop(papi_eventset, papi_tmp_counts);
+    if (retval != PAPI_OK) {
+        fprintf(stderr,"Error stopping:  %s\n",
+                PAPI_strerror(retval));
+    }
+    if (accum) {
+        for (int i = 0; i < papi_num_events; i++)
+            counters[i] += papi_tmp_counts[i];
+    } else {
+        for (int i = 0; i < papi_num_events; i++)
+            counters[i] = papi_tmp_counts[i];
+    }
+}
+
+void HCLIB_PAPI_Show(int64_t src, size_t pkg_size, int mbox_id, long long *counters, int num_sends) {
+    FILE *fp = get_papi_trace_fptr(false);
+    int64_t dst = shmem_my_pe();
+    int nd_s = PEtoNodeMap[src];
+    int nd_d = PEtoNodeMap[dst];
+    long long tot_ins = counters[1];
+    long long lst_ins = counters[2];
+    double stamp = get_clock_time();
+    fprintf(fp, "%d, %ld, %d, %ld, %ld, %d, %d, %lld, %lld, %lf\n",
+	    nd_s, src, nd_d, dst, pkg_size, mbox_id, num_sends, tot_ins, lst_ins, stamp);
+    fflush(fp);
+}
+
+class PapiCounter {
+ public:
+  int num_sends;
+  long long *papi_counters;
+
+  PapiCounter() {
+    num_sends = 0;
+    papi_counters = (long long *) calloc(papi_num_events, sizeof(long long));
+  }
+
+  void init() {
+    num_sends = 0;
+    for (int i = 0; i < papi_num_events; i++)
+      papi_counters[i] = 0;
+  }
+};
+
+// #define PAPI_TRACER_DEBUG1
+// #define PAPI_TRACER_DEBUG2
+class PapiTracer {
+  std::vector<PapiCounter> counters;
+  std::vector<int> reuse_idcs;
+  PapiCounter *curr;
+  int curr_idx;
+
+ public:
+  void init() {
+    counters.clear();
+    reuse_idcs.clear();
+    curr = NULL;
+    curr_idx = -1;
+#ifdef PAPI_TRACER_DEBUG1
+    printf("PapiTracer: PE%d init\n", shmem_my_pe());
+#endif
+    HCLIB_PAPI_Init();
+  }
+
+  void start() {
+    bool to_add = reuse_idcs.empty();
+    if (to_add) {
+      counters.push_back(PapiCounter());
+      curr_idx = counters.size() - 1;
+    } else {
+      curr_idx = reuse_idcs.back();
+      reuse_idcs.pop_back();
+      counters[curr_idx].init();
+    }
+    curr = &(counters[curr_idx]);
+#ifdef PAPI_TRACER_DEBUG2
+    const char *msg = to_add ? "added" : "reused";
+    printf("PapiTracer: PE%d start %d (counter %s)\n", shmem_my_pe(), curr_idx, msg);
+#endif
+    HCLIB_PAPI_Start();
+  }
+
+  int pause() {
+    HCLIB_PAPI_Stop(curr->papi_counters);
+#ifdef PAPI_TRACER_DEBUG2
+    printf("PapiTracer: PE%d pause %d\n", shmem_my_pe(), curr_idx);
+#endif
+    return curr_idx;
+  }
+
+  void resume(int idx) {
+    curr_idx = idx;
+    curr = &(counters[curr_idx]);
+    (curr->num_sends)++;
+#ifdef PAPI_TRACER_DEBUG2
+    printf("PapiTracer: PE%d resume %d\n", shmem_my_pe(), curr_idx);
+#endif
+    HCLIB_PAPI_Start();
+  }
+
+  void end_and_dump(int64_t src, size_t pkg_size, int mb_id) {
+    HCLIB_PAPI_Stop(curr->papi_counters);
+    HCLIB_PAPI_Show(src, pkg_size, mb_id, curr->papi_counters, curr->num_sends);
+#ifdef PAPI_TRACER_DEBUG2
+    printf("PapiTracer: PE%d end %d\n", shmem_my_pe(), curr_idx);
+#endif
+    reuse_idcs.push_back(curr_idx);
+    curr_idx = -1;
+    curr = NULL;
+  }
+};
+#endif // ENABLE_TRACE_PAPI
+#endif // ENABLE_TRACE
+
+#ifdef USE_LAMBDA
+class BaseLambdaPacket {
+  public:
+    virtual void invoke() = 0;
+    virtual size_t get_bytes() = 0;
+    virtual ~BaseLambdaPacket() {}
+};
+
+template<typename L>
+class LambdaPacket : public BaseLambdaPacket {
+    L lambda;
+
+  public:
+    LambdaPacket(L lambda) : lambda(lambda) {}
+
+    void invoke() {
+        lambda();
+    }
+
+    size_t get_bytes() {
+        return sizeof(*this);
+    }
+};
+
+template<typename T>
+struct BufferPacket {
+    T data;
+    int64_t rank;
+    BaseLambdaPacket* lambda_pkt;
+
+    BufferPacket() : rank(0) {}
+    BufferPacket(T data, int64_t rank) : data(data), rank(rank) {}
+    BufferPacket(int64_t rank, BaseLambdaPacket* lambda_pkt) : rank(rank), lambda_pkt(lambda_pkt) {}
+};
+
+#else // USE_LAMBDA
+
+template<typename T>
+struct BufferPacket {
+    T data;
+    int64_t rank;
+
+    BufferPacket() : rank(0) {}
+    BufferPacket(T data, int64_t rank) : data(data), rank(rank) {}
+};
+
+#endif // USE_LAMBDA
+
+template<typename T, int SIZE>
+class Mailbox {
+
+    hclib::conveyor::safe_buffer<BufferPacket<T>> *buff=nullptr;
+    convey_t* conv=nullptr;
+    BufferPacket<T> done_mark;
+    hclib::promise_t<int> worker_loop_end;
+    bool is_early_exit = false, is_done = false;
+    Mailbox* dep_mb = nullptr;
+    int mb_id;
+    std::vector<int> dep_mbs;
+    int predecessor_mbs_count = 0;
+    bool is_cyclic = false;
+    bool done_called = false;
+    int *GLOBAL_DONE;
+    int *LOCAL_DONE;
+#ifdef ENABLE_TRACE_PAPI
+    PapiTracer *papi_tracer = NULL;
+#endif
+#ifdef ENABLE_TCOMM_PROFILING
+    uint64_t *t_process;
+    uint64_t *recv_count;
+#endif
+
+  public:
+
+    Mailbox() {
+        buff = new hclib::conveyor::safe_buffer<BufferPacket<T>>(SIZE);
+#ifdef SELECTOR_DEBUG
+        printf("Creating Mailbox\n");
+#endif
+    }
+
+    ~Mailbox() {
+#ifdef SELECTOR_DEBUG
+        printf("Deleting Mailbox\n");
+#endif
+        //delete buff;
+        //convey_free(conv);
+    }
+
+    std::function<void (T, int)> process;
+
+    hclib::future_t<int>* get_worker_loop_finish() {
+        return worker_loop_end.get_future();
+    }
+
+    hclib::conveyor::safe_buffer<BufferPacket<T>>* get_buffer() {
+        return buff;
+    }
+
+    void set_is_early_exit(bool val) {
+        is_early_exit = val;
+    }
+
+    void set_dep_mb(Mailbox* val) {
+        dep_mb = val;
+    }
+
+    Mailbox* get_dep_mb() {
+        return dep_mb;
+    }
+
+    void set_is_cyclic(bool val) {
+        is_cyclic = val;
+    }
+
+    bool get_is_cyclic() {
+        return is_cyclic;
+    }
+
+    void set_done_called(bool val) {
+        done_called = val;
+    }
+
+    bool get_done_called() {
+        return done_called;
+    }
+
+    void add_dep_mbs(std::vector<int> successor_mbs) {
+        for (int64_t const& successor_mb_id : successor_mbs) {
+            dep_mbs.push_back(successor_mb_id);
+        }
+    }
+
+    std::vector<int> get_dep_mbs() {
+        return dep_mbs;
+    }
+
+    int64_t get_predecessor_mbs_count() {
+        return predecessor_mbs_count;
+    }
+
+    void inc_predecessor_mbs_count() {
+        predecessor_mbs_count++;
+    }
+
+    void dec_predecessor_mbs_count() {
+        predecessor_mbs_count--;
+    }
+
+#ifdef ENABLE_TRACE_PAPI
+    void start(int mid, int* global_done, int* local_done, PapiTracer *ptrc) {
+      papi_tracer = ptrc;
+#elif defined (ENABLE_TCOMM_PROFILING)
+    void start(int mid, int* global_done, int* local_done, uint64_t *_t_process, uint64_t *_recv_count) {
+      t_process = _t_process;
+      recv_count = _recv_count;
+#else
+    void start(int mid, int* global_done, int* local_done) {
+#endif
+        mb_id = mid;
+        GLOBAL_DONE = global_done;
+        LOCAL_DONE = local_done;
+#ifdef USE_LAMBDA
+        conv = convey_new_elastic(ELASTIC_BUFFER_SIZE, SIZE_MAX, 0, NULL, convey_opt_PROGRESS);
+#else
+        //buff = new hclib::conveyor::safe_buffer<BufferPacket<T>>(SIZE);
+        //conv = convey_new(SIZE_MAX, 0, NULL, 0);
+        conv = convey_new(SIZE_MAX, 0, NULL, convey_opt_PROGRESS);
+#endif
+        assert( conv != nullptr );
+        convey_begin(conv, sizeof(T), 0);
+        done_mark.rank = DONE_MARK;
+    }
+
+    void end() {
+        delete buff;
+        convey_free(conv);
+    }
+
+#ifdef USE_LAMBDA
+    template<typename L>
+    bool send(int rank, L lambda) {
+        if(buff->full()) {
+            if(is_early_exit)
+                return false;
+            else
+                while(buff->full()) hclib::yield_at(nic);
+        }
+        assert(!buff->full());
+        buff->push_back(BufferPacket<T>(rank, new LambdaPacket<L>(lambda)));
+        return true;
+    }
+#else
+    bool send(T pkt, int rank) {
+
+#ifdef ENABLE_TRACE
+        trace_send(shmem_my_pe(), rank, sizeof(T));
+#endif 
+
+#ifdef USE_BUFFER
+        if(buff->full()) {
+            if(is_early_exit)
+                return false;
+            else
+                while(buff->full()) hclib::yield_at(nic);
+        }
+        assert(!buff->full());
+        buff->push_back(BufferPacket<T>(pkt, rank));
+        return true;
+#else // USE_BUFFER
+        int ret = convey_push(conv, &pkt, rank);
+        if(is_early_exit)
+            return ret == convey_OK;
+        else if(ret != convey_OK)
+            while(convey_push(conv, &pkt, rank) != convey_OK) hclib::yield_at(nic);
+        return true;
+#endif // USE_BUFFER
+    }
+#endif // USE_LAMBDA
+
+    void done() {
+        is_done = true;
+        while(buff->full()) hclib::yield_at(nic);
+        assert(!buff->full());
+        buff->push_back(done_mark);
+    }
+
+
+#ifndef YIELD_LOOP
+    int start_worker_loop(int status=0) {
+
+        assert(status == 0);
+        hclib::async_at([=]{
+#ifdef USE_BUFFER
+
+          BufferPacket<T> bp;
+          if(buff->size() > 0)
+            bp = buff->at(0);
+
+          //Assumes once 'advance' is called with done=true, the conveyor
+          //enters endgame and subsequent value of 'done' is ignored
+          while(convey_advance(conv, bp.rank == DONE_MARK || *GLOBAL_DONE == -1)) {
+              int i;
+              size_t buff_size = buff->size();
+              for(i=0;i<buff_size; i++){
+                  bp = buff->operator[](i);
+                  if( bp.rank == DONE_MARK || *GLOBAL_DONE == -1 ) break;
+#ifdef USE_LAMBDA
+                  if( !convey_epush(conv, bp.lambda_pkt->get_bytes(), bp.lambda_pkt, bp.rank)) break;
+#else
+                  if( !convey_push(conv, &(bp.data), bp.rank)) break;
+#endif //  USE_LAMBDA
+              }
+
+	          if(i>0)
+              {
+#ifdef USE_LOCK
+                  std::lock_guard<std::mutex> lg(buff->get_mutex());
+#endif
+                  buff->erase_begin(i);
+              }
+#else // USE_BUFFER
+          while(convey_advance(conv, is_done)) {
+#endif // USE_BUFFER
+              int64_t from;
+#ifdef USE_LAMBDA
+              convey_item_t item;
+              while( convey_epull(conv, &item) == convey_OK) {
+                  BaseLambdaPacket* data = (BaseLambdaPacket*)item.data;
+                  data->invoke();
+              }
+#else
+
+              T pop;
+              while( convey_pull(conv, &pop, &from) == convey_OK) {
+#ifdef ENABLE_TRACE_PAPI
+                  papi_tracer->start();
+#endif
+#ifdef ENABLE_TCOMM_PROFILING
+                  uint64_t t1 = start_tsc();
+#endif
+                  process(pop, from);
+#ifdef ENABLE_TCOMM_PROFILING
+                  *t_process = *t_process + (stop_tsc() - t1);
+                  *recv_count = *recv_count + 1;
+#endif
+#ifdef ENABLE_TRACE_PAPI
+                  papi_tracer->end_and_dump(from, sizeof(T), mb_id);
+#endif
+              }
+#endif // USE_LAMBDA
+
+              hclib::yield_at(nic);
+          }
+          worker_loop_end.put(1);
+        }, nic);
+        return 0;
+    }
+
+#else // YIELD_LOOP
+
+    int start_worker_loop(int status=0) {
+
+          while(true) {
+              size_t buff_size = buff->size();
+              if(buff_size > 0) break;
+              if(status == 1)
+                  return 1;
+              else {
+                  assert(status == 2);
+                  break;
+              }
+          }
+
+          BufferPacket<T> bp;
+          if(buff->size() > 0)
+            bp = buff->at(0);
+
+          while(convey_advance(conv, bp.rank == DONE_MARK || *GLOBAL_DONE == -1)) {
+              int i;
+              size_t buff_size = buff->size();
+              for(i=0;i<buff_size; i++){
+                  bp = buff->operator[](i);
+                  if( bp.rank == DONE_MARK || *GLOBAL_DONE == -1 ) break;
+#ifdef USE_LAMBDA
+                  if( !convey_epush(conv, bp.lambda_pkt->get_bytes(), bp.lambda_pkt, bp.rank)) break;
+#else
+                  if( !convey_push(conv, &(bp.data), bp.rank)) break;
+#endif //  USE_LAMBDA
+              }
+
+	          if(i>0)
+              {
+#ifdef USE_LOCK
+                  std::lock_guard<std::mutex> lg(buff->get_mutex());
+#endif
+                  buff->erase_begin(i);
+              }
+              int64_t from;
+#ifdef USE_LAMBDA
+              convey_item_t item;
+              while( convey_epull(conv, &item) == convey_OK) {
+                  BaseLambdaPacket* data = (BaseLambdaPacket*)item.data;
+                  data->invoke();
+              }
+#else
+
+              T pop;
+              while( convey_pull(conv, &pop, &from) == convey_OK) {
+#ifdef ENABLE_TRACE_PAPI
+                  papi_tracer->start();
+#endif
+                  process(pop, from);
+#ifdef ENABLE_TRACE_PAPI
+                  papi_tracer->end_and_dump(from, sizeof(T), mb_id);
+#endif
+              }
+#endif // USE_LAMBDA
+
+              return 2;
+          }
+          worker_loop_end.put(1);
+          return 0;
+    }
+
+#endif // YIELD_LOOP
+
+};
+
+// ==============================
+// Variadic Selector<SIZE, Ts...>
+// ==============================
+template<int SIZE = BUFFER_SIZE, typename... Ts>
+class Selector {
+
+  private:
+    static constexpr std::size_t N = sizeof...(Ts);
+
+    std::tuple<Mailbox<Ts, SIZE>...> mb;   // heterogeneous mailboxes
+
+    int *GLOBAL_DONE;
+    int *LOCAL_DONE;
+
+#ifdef ENABLE_TRACE
+    void createPEtoNodeMap() {
+        PEtoNodeMap = (int*)shmem_malloc(shmem_n_pes()*sizeof(int));
+        if(PEtoNodeMap==NULL){
+            std::cout << "ERROR: Unable to allocate space for PEtoNodeMap pointer\n" << std::endl;
+            abort();
+        }
+        char *nid = getenv("SLURM_NODEID");
+        if(nid==NULL){
+            std::cout << "ERROR: Unable to retrieve NodeID\n" << std::endl;
+            abort();
+        }
+        int myNodeID = atoi(nid);
+        for (int i = 0; i < shmem_n_pes(); i++) {
+            shmem_put32(PEtoNodeMap+shmem_my_pe(), &myNodeID, 1, i);
+        }
+        shmem_barrier_all();
+        if(myNodeID==0 && shmem_my_pe()==0){
+            printf("Logical actor message trace enabled\n");
+            for (int i = 0; i < shmem_n_pes(); i++) {
+                printf("PE:%d, Node %d\n", i, PEtoNodeMap[i]);
+            }
+        }
+    }
+
+#ifdef ENABLE_TRACE_PAPI
+  PapiTracer papi_tracer;
+#endif
+#endif
+#ifdef ENABLE_TCOMM_PROFILING
+    uint64_t t_start = 0;              // the time at which the start API is called
+    uint64_t t_inside_finish = 0;      // the time between start and done
+    uint64_t t_outside_finish = 0;     // the time between start and the end of finish
+    uint64_t t_send = 0;               // the cumulative time to do send (includes message handler)
+    uint64_t t_send_in_process = 0;    // the cumulative time to do send  (includes message handler)
+    uint64_t t_done = 0;               // the time at which the done API is called
+    uint64_t t_wait = 0;               // the time between done and the end of finish
+    uint64_t t_process = 0;            // the cumulative time to do process
+    uint64_t send_count = 0;           // # of sends
+    uint64_t send_in_process_count = 0;// # of sends  (in process)
+    uint64_t recv_count = 0;           // # of recvs
+#endif
+
+#ifndef YIELD_LOOP
+    void start_worker_loop_all() {
+        std::apply([&](auto&... m){ (m.start_worker_loop(), ...); }, mb);
+    }
+#else
+    void start_worker_loop_all() {
+        hclib::async_at([=]{
+            // YIELD_LOOP version (generalized) – run cooperative loops
+            // For simplicity, call the non-blocking start_worker_loop() of each
+            std::apply([&](auto&... m){ (m.start_worker_loop(), ...); }, mb);
+        }, nic);
+    }
+#endif
+
+    // Helper: runtime dispatch to mailbox i with callable f(auto& m)
+    template <typename F, std::size_t... Is>
+    void dispatch_index_impl(std::size_t i, F&& f, std::index_sequence<Is...>) {
+        bool hit = ((i == Is ? (f(std::get<Is>(mb)), true) : false) || ...);
+        (void)hit;
+    }
+    template <typename F>
+    void dispatch_index(std::size_t i, F&& f) {
+        dispatch_index_impl(i, std::forward<F>(f), std::make_index_sequence<N>{});
+    }
+
+    hclib::promise_t<int> end_prom;
+    int num_work_loop_end = 0;
+
+    void initialize_local_global_done() {
+        GLOBAL_DONE = (int*)shmem_malloc(sizeof(int));
+        LOCAL_DONE  = (int*)shmem_malloc(sizeof(int));
+
+        if(GLOBAL_DONE==NULL){
+            std::cout << "ERROR: Unable to allocate space for GLOBAL_DONE pointer\n" << std::endl;
+            abort();
+        }
+        if(LOCAL_DONE==NULL){
+            std::cout << "ERROR: Unable to allocate space for LOCAL_DONE pointer\n" << std::endl;
+            abort();
+        }
+
+        *GLOBAL_DONE = 0;
+        *LOCAL_DONE = 0;
+    }
+
+    // ---- Dependency graph helpers (index-based) ----
+    void check_cyclic_rec(int mb_id) {
+        // get successors by index and propagate
+        dispatch_index(mb_id, [&](auto& mref){
+            std::vector<int> successors_mb = mref.get_dep_mbs();
+            for (int const& successor_mb_id : successors_mb) {
+                dispatch_index(successor_mb_id, [&](auto& sref){
+                    sref.inc_predecessor_mbs_count();
+                });
+                if (successor_mb_id == mb_id) {
+                    mref.set_is_cyclic(true);
+                } else {
+                    check_cyclic_rec(successor_mb_id);
+                }
+            }
+        });
+    }
+
+  public:
+
+    // public to keep parity with previous API (users can still access mb via send<>() etc.)
+    static constexpr std::size_t num_mailboxes = N;
+
+    public:
+        template<std::size_t I>
+        auto& mailbox() {
+            static_assert(I < N, "mailbox<I>: index out of range");
+            return std::get<I>(mb);
+        }
+
+    // ---------------- Ctors / Dtor ----------------
+    Selector(bool is_start = false) {
+        #ifdef ENABLE_TRACE
+        createPEtoNodeMap();
+        #endif
+        initialize_local_global_done();
+        if(is_start) {
+            start();
+        }
+    }
+
+    ~Selector() {
+        std::apply([&](auto&... m){ (m.end(), ...); }, mb);
+    }
+
+    void start() {
+#ifdef ENABLE_TRACE_PAPI
+        papi_tracer.init();
+#endif
+#ifdef ENABLE_TCOMM_PROFILING
+        t_start = start_tsc();
+#endif
+        // start all mailboxes
+        std::apply([&](auto&... m){
+            int id = 0;
+            ((m.start(id++, GLOBAL_DONE, LOCAL_DONE
+#ifdef ENABLE_TRACE_PAPI
+            , &papi_tracer
+#elif defined(ENABLE_TCOMM_PROFILING)
+            , &t_process, &recv_count
+#endif
+            ), ...));
+        }, mb);
+
+        start_worker_loop_all();
+
+        // check if mailbox has cyclic dependency
+        for (int mb_id = 0; mb_id < (int)N; mb_id++) {
+            check_cyclic(mb_id);
+        }
+
+#ifdef ENABLE_TRACE_PAPI
+        papi_tracer.start();
+#endif
+    }
+
+    void check_cyclic(int mb_id) {
+        check_cyclic_rec(mb_id);
+    }
+
+#ifdef USE_LAMBDA
+    // ------------- SEND (lambda) -------------
+    template<std::size_t I, typename L>
+    bool send(int rank, L lambda) {
+        static_assert(I < N, "Mailbox index out of range");
+#ifdef ENABLE_TRACE_PAPI
+        int idx = papi_tracer.pause();
+        bool ret = std::get<I>(mb).send(rank, lambda);
+        papi_tracer.resume(idx);
+        return ret;
+#elif defined(ENABLE_TCOMM_PROFILING)
+        uint64_t t1 = start_tsc();
+        bool ret = std::get<I>(mb).send(rank, lambda);
+        if constexpr (I == 0) { t_send += stop_tsc() - t1; send_count++; }
+        else                  { t_send_in_process += stop_tsc() - t1; send_in_process_count++; }
+        return ret;
+#else
+        return std::get<I>(mb).send(rank, lambda);
+#endif
+    }
+
+    template<typename L>
+    bool send_by_index(std::size_t i, int rank, L lambda) {
+        bool ok = false;
+        dispatch_index(i, [&](auto& mref){
+#ifdef ENABLE_TRACE_PAPI
+            int idx = papi_tracer.pause();
+            ok = mref.send(rank, lambda);
+            papi_tracer.resume(idx);
+#elif defined(ENABLE_TCOMM_PROFILING)
+            uint64_t t1 = start_tsc();
+            ok = mref.send(rank, lambda);
+            if (i == 0) { t_send += stop_tsc() - t1; send_count++; }
+            else        { t_send_in_process += stop_tsc() - t1; send_in_process_count++; }
+#else
+            ok = mref.send(rank, lambda);
+#endif
+        });
+        return ok;
+    }
+#else
+    // ------------- SEND (payload) -------------
+    template<std::size_t I>
+    bool send(typename std::tuple_element<I, std::tuple<Ts...>>::type pkt, int rank) {
+        static_assert(I < N, "Mailbox index out of range");
+#ifdef ENABLE_TRACE_PAPI
+        int idx = papi_tracer.pause();
+        bool ret = std::get<I>(mb).send(pkt, rank);
+        papi_tracer.resume(idx);
+        return ret;
+#elif defined(ENABLE_TCOMM_PROFILING)
+        uint64_t t1 = start_tsc();
+        bool ret = std::get<I>(mb).send(pkt, rank);
+        if constexpr (I == 0) { t_send += stop_tsc() - t1; send_count++; }
+        else                  { t_send_in_process += stop_tsc() - t1; send_in_process_count++; }
+        return ret;
+#else
+        return std::get<I>(mb).send(pkt, rank);
+#endif
+    }
+
+    template<typename Pkt>
+    bool send_by_index(std::size_t i, Pkt pkt, int rank) {
+        bool ok = false;
+        dispatch_index(i, [&](auto& mref){
+            ok = mref.send(pkt, rank);
+        });
+        return ok;
+    }
+#endif // USE_LAMBDA
+
+    // ---------- Termination ----------
+    void initiate_global_done() { // signals current PE termination
+        *LOCAL_DONE = -1; 
+
+        int global_done_flag = 0;
+        int local_done_value;
+
+        // fetch LOCAL_DONE on all PEs
+        for (int pe_id = 0; pe_id < shmem_n_pes(); pe_id++) {
+            if (pe_id == shmem_my_pe()) {
+                local_done_value = *LOCAL_DONE;
+            } else {
+                local_done_value = shmem_int_g(LOCAL_DONE, pe_id);
+            }
+            if (!local_done_value) { break; }
+            global_done_flag += local_done_value;
+        }
+
+        // if all LOCAL_DONE == (-1)*shmem_n_pes then can (safely) invoke global termination
+        if (global_done_flag == (-1 * shmem_n_pes())) {
+            global_done();
+        }
+    }
+
+    void global_done() { // invokes global termination on all PEs
+        for (int pe_id = 0; pe_id < shmem_n_pes(); pe_id++) {
+            if (pe_id == shmem_my_pe()) {
+                *GLOBAL_DONE = -1;
+            } else {
+                shmem_int_p(GLOBAL_DONE, -1, pe_id);
+            }
+        }
+    }
+
+    // done for specific mailbox id (runtime index)
+    void done_by_index(int start_mb_id) {
+#ifdef ENABLE_TRACE_PAPI
+        if (start_mb_id == 0)
+            papi_tracer.end_and_dump(shmem_my_pe(), 0, -1);
+#endif
+#ifdef ENABLE_TCOMM_PROFILING
+        if (start_mb_id == 0) {
+            t_inside_finish = stop_tsc() - t_start;
+            t_done = stop_tsc();
+        }
+#endif
+        auto chain = [this](auto&& self, int id) -> void {
+            dispatch_index(id, [&](auto& mref){
+                mref.done();
+                hclib::async_await_at([=]() {
+                    num_work_loop_end++;
+                    if (num_work_loop_end < (int)N) {
+                        self(self, (id + 1) % (int)N);  // chain to next mailbox
+                    } else {
+                        end_prom.put(1);
+#ifdef ENABLE_TCOMM_PROFILING
+                        t_outside_finish = stop_tsc() - t_start;
+                        t_wait = stop_tsc() - t_done;
+#endif
+                    }
+                }, mref.get_worker_loop_finish(), nic);
+            });
+        };
+        chain(chain, start_mb_id);
+    }
+
+    // done for specific mailbox (compile-time index)
+    template<std::size_t I>
+    void done() {
+        done_by_index(static_cast<int>(I));
+    }
+
+    // done_extended (keeps original behavior using index graph)
+    void done_extended(int mb_id) {
+        dispatch_index(mb_id, [&](auto& mref){
+            bool mb_cyclic = mref.get_is_cyclic();
+            bool mb_done_called = false;
+            if (mb_cyclic) mb_done_called = mref.get_done_called();
+
+            if ((!mb_cyclic) || (mb_cyclic && !mb_done_called)) {
+                mref.done();
+                if (mb_cyclic) mref.set_done_called(true);
+                hclib::async_await_at([=]() {
+                    num_work_loop_end++;
+
+                    std::vector<int> successor_mbs = mref.get_dep_mbs();
+                    for (int const& successor_mb_id : successor_mbs) {
+                        dispatch_index(successor_mb_id, [&](auto& sref){
+                            int num_predecessors = sref.get_predecessor_mbs_count();
+                            if (num_predecessors == 1) {
+                                done_extended(successor_mb_id);
+                            } else {
+                                sref.dec_predecessor_mbs_count();
+                            }
+                        });
+                    }
+                    
+                    if (num_work_loop_end == (int)N) {
+                        end_prom.put(1);
+                    }
+                }, mref.get_worker_loop_finish(), nic);
+            }
+        });
+    }
+
+    // legacy single-mailbox convenience
+    void done() {
+        static_assert(N==1, "Selector::done() without index only valid for N==1");
+        done<0>();
+    }
+
+    hclib::future_t<int>* get_future() {
+        return end_prom.get_future();
+    }
+
+#ifdef ENABLE_TCOMM_PROFILING
+  void print_profiling(char *prefix=(char*)"") {
+      printf("%s [PE%d] T_inside_finish (start - done): %" PRIu64 " cycles\n", prefix, shmem_my_pe(), t_inside_finish);
+      printf("%s [PE%d] T_wait (done - finish): %" PRIu64 " cycles\n", prefix, shmem_my_pe(), t_wait);
+      printf("%s [PE%d] T_outside_finish (start - finish): %" PRIu64 " cycles\n", prefix, shmem_my_pe(), t_outside_finish);
+      printf("%s [PE%d] T_sends (count=%" PRIu64 "): %" PRIu64 " cycles\n", prefix, shmem_my_pe(), send_count, t_send);
+      printf("%s [PE%d] T_send_in_process (count=%" PRIu64 "): %" PRIu64 " cycles\n", prefix, shmem_my_pe(), send_in_process_count, t_send_in_process);
+      printf("%s [PE%d] T_process (count=%" PRIu64 "): %" PRIu64 " cycles\n", prefix, shmem_my_pe(), recv_count, t_process);
+
+      uint64_t T_MAIN = t_inside_finish - t_send;
+      uint64_t T_PROC = t_process - t_send_in_process;
+      uint64_t T_WAIT = t_wait;
+      uint64_t T_COMM = (t_send + T_WAIT) - T_PROC;
+      uint64_t T_TOTAL = (T_MAIN+T_COMM+T_PROC);
+
+      if (((t_outside_finish >= T_TOTAL) && (t_outside_finish - T_TOTAL > 0.01 * t_outside_finish))
+          || ((t_outside_finish < T_TOTAL) && (T_TOTAL - t_outside_finish > 0.01 * t_outside_finish))) {
+          printf("%s [PE%d] T_TOTAL would be much bigger/smaller than T_finish\n", prefix, shmem_my_pe());
+      }
+
+      printf("%s [PE%d] TCOMM_PROFILING (T_MAIN, T_COMM, T_PROC, T_TOTAL), %" PRIu64 ", %" PRIu64 ", %" PRIu64 ", %" PRIu64 "\n", prefix, shmem_my_pe(), T_MAIN, T_COMM, T_PROC, T_TOTAL);
+      printf("%s [PE%d] TCOMM_PROFILING (T_MAIN/T_TOTAL, T_COMM/T_TOTAL, T_PROC/T_TOTAL), %lf, %lf, %lf\n", prefix, shmem_my_pe(), (double)T_MAIN/(double)T_TOTAL, (double)T_COMM/(double)T_TOTAL, (double)T_PROC/(double)T_TOTAL);
+  }
+#endif
+};
+
+// Backward-compatible single-mailbox alias
+template<typename T=int64_t>
+using Actor = Selector<BUFFER_SIZE, T>;
+
+}; // namespace hclib
+
+#endif // SELECTOR_H

--- a/modules/bale_actor/test/selector-mb/Makefile
+++ b/modules/bale_actor/test/selector-mb/Makefile
@@ -1,0 +1,17 @@
+include $(HCLIB_ROOT)/../modules/bale_actor/inc/hclib_bale_actor.pre.mak
+include $(HCLIB_ROOT)/include/hclib.mak
+include $(HCLIB_ROOT)/../modules/bale_actor/inc/hclib_bale_actor.post.mak
+
+SRUN ?= oshrun
+
+TARGETS=ig-selector
+
+all: $(TARGETS)
+
+%: %.cpp
+	$(CXX) -g -O3 -std=c++17 -DUSE_SHMEM=1 $(HCLIB_CFLAGS) $(HCLIB_LDFLAGS) -o $@ $^ $(HCLIB_LDLIBS) -lspmat -lconvey -lexstack -llibgetput -lhclib_bale_actor -lm
+test:
+	for target in $(TARGETS); do $(SRUN) ./$$target; done
+
+clean:
+	rm -f $(TARGETS)

--- a/modules/bale_actor/test/selector-mb/ig-selector.cpp
+++ b/modules/bale_actor/test/selector-mb/ig-selector.cpp
@@ -1,0 +1,175 @@
+#include <shmem.h>
+extern "C" {
+#include <spmat.h>
+}
+#include "selector-mb.h"
+
+#define THREADS   shmem_n_pes()
+#define MYTHREAD  shmem_my_pe()
+
+constexpr std::size_t MB_REQUEST  = 0;
+constexpr std::size_t MB_RESPONSE = 1;
+
+struct Resp2x64 {
+    int64_t idx;
+    int64_t val;
+};
+
+static inline uint64_t pack_req(uint64_t req_idx, uint64_t local_idx) {
+    return (req_idx << 32) | (local_idx & 0xffffffffULL);
+}
+static inline void unpack_req(uint64_t packed, uint64_t &req_idx, uint64_t &local_idx) {
+    req_idx   = (packed >> 32);
+    local_idx = (packed & 0xffffffffULL);
+}
+
+/*!
+ * \brief Selector variant of indexgather using variadic mailboxes.
+ * \param tgt       target array for gathered values (length l_num_req)
+ * \param pckindx   packed (local_index<<16 | pe) for each request (length l_num_req)
+ * \param l_num_req number of requests per PE
+ * \param ltable    local partition of the distributed table (length ltab_siz)
+ * \return average runtime across PEs
+ */
+double ig_selector(int64_t *tgt, int64_t *pckindx, int64_t l_num_req, int64_t *ltable) {
+    using IGSel = hclib::Selector<BUFFER_SIZE, uint64_t, Resp2x64>; // mb0: uint64_t, mb1: Resp2x64
+    minavgmaxD_t stat[1];
+
+    IGSel sel(false);
+    sel.template mailbox<MB_REQUEST>().process = [ltable, &sel](uint64_t packed, int sender_rank) {
+        uint64_t req_idx_u = 0, local_idx_u = 0;
+        unpack_req(packed, req_idx_u, local_idx_u);
+
+        Resp2x64 r;
+        r.idx = static_cast<int64_t>(req_idx_u);
+        r.val = ltable[static_cast<size_t>(local_idx_u)];
+
+        sel.template send<MB_RESPONSE>(r, sender_rank);
+    };
+
+    sel.template mailbox<MB_RESPONSE>().process = [tgt](Resp2x64 r, int) {
+        tgt[r.idx] = r.val;
+    };
+
+    lgp_barrier();
+    double tm = wall_seconds();
+
+    hclib::finish([&]() {
+        sel.start();
+        for (int64_t i = 0; i < l_num_req; i++) {
+            int64_t lindx = (pckindx[i] >> 16);              // local index at destination PE
+            int      dest = static_cast<int>(pckindx[i] & 0xffff); // destination PE
+            uint64_t req  = pack_req(static_cast<uint64_t>(i),
+                                     static_cast<uint64_t>(lindx));
+            sel.template send<MB_REQUEST>(req, dest);
+        }
+        sel.template done<MB_REQUEST>();
+    });
+
+    tm = wall_seconds() - tm;
+    lgp_barrier();
+    lgp_min_avg_max_d(stat, tm, THREADS);
+    return stat->avg;
+}
+
+int64_t ig_check_and_zero(int64_t use_model, int64_t *tgt, int64_t *index, int64_t l_num_req) {
+    int64_t errors = 0;
+    lgp_barrier();
+    for (int64_t i = 0; i < l_num_req; i++) {
+        if (tgt[i] != (-1) * (index[i] + 1)) {
+            errors++;
+            if (errors < 5) {
+                fprintf(stderr,"ERROR: model %ld: Thread %d: tgt[%ld] = %ld != %ld)\n",
+                        use_model, MYTHREAD, i, tgt[i], (-1)*(index[i] + 1));
+            }
+        }
+        tgt[i] = 0;
+    }
+    if (errors > 0)
+        fprintf(stderr,"ERROR: %ld: %ld total errors on thread %d\n", use_model, errors, MYTHREAD);
+    lgp_barrier();
+    return errors;
+}
+
+int main(int argc, char * argv[]) {
+
+  const char *deps[] = { "system", "bale_actor" };
+  hclib::launch(deps, 2, [=] {
+
+    int64_t i;
+    int64_t buf_cnt = 1024;
+    int64_t models_mask = 0;
+    int64_t ltab_siz = 100000;
+    int64_t l_num_req  = 1000000;
+    int64_t cores_per_node = 0;
+    int64_t num_errors = 0L, total_errors = 0L;
+    int64_t printhelp = 0;
+
+    int opt;
+    while ((opt = getopt(argc, argv, "hb:M:n:c:T:")) != -1) {
+      switch(opt) {
+      case 'h': printhelp = 1; break;
+      case 'b': sscanf(optarg,"%ld" ,&buf_cnt);   break;
+      case 'M': sscanf(optarg,"%ld" ,&models_mask);  break;
+      case 'n': sscanf(optarg,"%ld" ,&l_num_req);   break;
+      case 'T': sscanf(optarg,"%ld" ,&ltab_siz);   break;
+      case 'c': sscanf(optarg,"%ld" ,&cores_per_node); break;
+      default:  break;
+      }
+    }
+
+    T0_fprintf(stderr,"Running ig on %d threads\n", THREADS);
+    T0_fprintf(stderr,"buf_cnt (number of buffer pkgs)      (-b)= %ld\n", buf_cnt);
+    T0_fprintf(stderr,"Number of Request / thread           (-n)= %ld\n", l_num_req );
+    T0_fprintf(stderr,"Table size / thread                  (-T)= %ld\n", ltab_siz);
+    T0_fprintf(stderr,"models_mask                          (-M)= %ld\n", models_mask);
+    T0_fprintf(stderr,"models_mask is or of 1,2,4,8,16 for agi,exstack,exstack2,conveyor,alternate)\n");
+
+    // Allocate and populate the shared table array
+    int64_t tab_siz = ltab_siz * THREADS;
+    int64_t * table  = (int64_t*)lgp_all_alloc(tab_siz, sizeof(int64_t)); assert(table != NULL);
+    int64_t * ltable = lgp_local_part(int64_t, table);
+
+    // Fill table with negative of global index for checking
+    for (i=0; i<ltab_siz; i++)
+      ltable[i] = (-1)*(i*THREADS + MYTHREAD + 1);
+
+    int64_t *index   = (int64_t*)calloc(l_num_req, sizeof(int64_t)); assert(index != NULL);
+    int64_t *pckindx = (int64_t*)calloc(l_num_req, sizeof(int64_t)); assert(pckindx != NULL);
+
+    int64_t indx, lindx, pe;
+    srand(MYTHREAD + 5);
+    for (i = 0; i < l_num_req; i++) {
+      indx = rand() % tab_siz;
+      index[i] = indx;
+      lindx = indx / THREADS;      // local index at destination PE
+      pe  = indx % THREADS;        // destination PE
+      pckindx[i] = (lindx << 16) | (pe & 0xffff);
+    }
+
+    int64_t *tgt  = (int64_t*)calloc(l_num_req, sizeof(int64_t)); assert(tgt != NULL);
+
+    lgp_barrier();
+
+    double laptime = ig_selector(tgt, pckindx, l_num_req, ltable);
+    double volume_per_node = (2*8*l_num_req*cores_per_node)*(1.0E-9);
+    double injection_bw = (cores_per_node > 0) ? (volume_per_node / laptime) : 0.0;
+
+    T0_fprintf(stderr,"  %8.3lf seconds\n", laptime);
+    (void)buf_cnt; (void)models_mask; (void)printhelp; (void)injection_bw;
+
+    num_errors += ig_check_and_zero(0, tgt, index, l_num_req);
+    total_errors = num_errors;
+    if (total_errors) {
+      T0_fprintf(stderr,"YOU FAILED!!!!\n");
+    }
+
+    lgp_barrier();
+    lgp_all_free(table);
+    free(index);
+    free(pckindx);
+    free(tgt);
+
+  });
+  return 0;
+}


### PR DESCRIPTION
Hi everyone,

We have created this PR for enabling different types of mailboxes in Selector class. We took help from the LLM code generation and transformation techniques (chatgpt premium). We have verified the working of `inc/selector-mb.h` and `test/selector-mb/ig-selector.cpp` as its usage. 

- We chose Index Gather since `mb0` requires only _one_ 64-bit **<index>** as a request, whereas `mb1` must contain _two_ 64-bit **<index, value>** as a response. This functionality is extensible to multiple mailboxes and hasn't been hardcoded for a fixed number of mailboxes.

```
[ssinghal74@atl1-1-02-008-2-1 selector-mb]$ srun -N 1 -n 4 ./ig-selector
Running ig on 4 threads
buf_cnt (number of buffer pkgs)      (-b)= 1024
Number of Request / thread           (-n)= 1000000
Table size / thread                  (-T)= 100000
models_mask                          (-M)= 0
models_mask is or of 1,2,4,8,16 for agi,exstack,exstack2,conveyor,alternate)
     0.092 seconds
[ssinghal74@atl1-1-02-008-2-1 selector-mb]$ 
```

### Performance difference between homogenous mailbox (original) vs [this]

All cores lie on single node.

| Cores | Execution Time (original) | Execution Time (this) |
|-------|----------------|----------------|
| 2 | 0.086 sec |  0.076 sec |
| 4 | 0.091 sec |  0.081 sec |
| 8 |  0.087 sec | 0.080 sec |
| 16 | 0.095 sec |  0.089 sec |

> Please note that we haven't tested functionalities of PAPI profiling, lambda selector and global extended barriers. For these please request a new PR. 


_Author:_ Shubhendra Pal Singhal (ssinghal74@gatech.edu)